### PR TITLE
ACE Medical status of players as a zeus overlay

### DIFF
--- a/CrowsZA/cfgFunctions.hpp
+++ b/CrowsZA/cfgFunctions.hpp
@@ -84,5 +84,10 @@ class CrowsZA_addon
 
 		// Remove Radio/Bino
 		class removeRadioBino {};
+
+		// MEDICAL TEXT HELP
+		class aceMedicalStatusHandler {};
+		class activateZeusTextDisplay {};
+		class addZeusTextDisplayEH {};
 	};
 };

--- a/CrowsZA/functions/fn_aceMedicStatusHandler.sqf
+++ b/CrowsZA/functions/fn_aceMedicStatusHandler.sqf
@@ -1,0 +1,74 @@
+
+/*/////////////////////////////////////////////////
+Author: Crowdedlight
+			   
+File: fn_aceMedicStatusHandler.sqf
+Parameters: 
+Return: none
+
+the PFH that updates the array with ace medic information for the display handler 
+
+*///////////////////////////////////////////////
+
+// only update and run when text is toggled
+if (!crowsZA_zeusTextDisplay) exitWith {};
+
+private _medicList = [];
+{
+	params["_player"];
+
+	// get ace medical information
+	private _openWounds = count(_x getVariable["ace_medical_openWounds",[]]);
+	private _heartrate = (_x getVariable["ace_medical_heartRate",-1]);
+	private _bleedingWounds = count(_x getVariable["ace_medical_woundBleeding",[]]);
+	private _inCRDC = (_x getVariable ["ace_medical_inCardiacArrest", false]);
+	private _inPain = (_x getVariable ["ace_medical_inPain", false]);
+
+	// save in list
+	_medicList pushBack [_openWounds, _heartrate, _bleedingWounds, _inCRDC, _inPain];
+} forEach allPlayers;
+
+crowsZA_medical_status_players = _medicList;
+
+
+// LIST FROM : https://github.com/acemod/ACE3/blob/master/addons/medical_engine/script_macros_medical.hpp
+//
+// #define VAR_BLOOD_PRESS       QEGVAR(medical,bloodPressure)    ace_medical_bloodPressure
+// #define VAR_BLOOD_VOL         QEGVAR(medical,bloodVolume)
+// #define VAR_WOUND_BLEEDING    QEGVAR(medical,woundBleeding)
+// #define VAR_CRDC_ARRST        QEGVAR(medical,inCardiacArrest)
+// #define VAR_HEART_RATE        QEGVAR(medical,heartRate)
+// #define VAR_PAIN              QEGVAR(medical,pain)
+// #define VAR_PAIN_SUPP         QEGVAR(medical,painSuppress)
+// #define VAR_PERIPH_RES        QEGVAR(medical,peripheralResistance)
+// #define VAR_UNCON             "ACE_isUnconscious"
+// #define VAR_OPEN_WOUNDS       QEGVAR(medical,openWounds)
+// #define VAR_BANDAGED_WOUNDS   QEGVAR(medical,bandagedWounds)
+// #define VAR_STITCHED_WOUNDS   QEGVAR(medical,stitchedWounds)
+// // These variables track gradual adjustments (from medication, etc.)
+// #define VAR_MEDICATIONS       QEGVAR(medical,medications)
+// // These variables track the current state of status values above
+// #define VAR_HEMORRHAGE        QEGVAR(medical,hemorrhage)
+// #define VAR_IN_PAIN           QEGVAR(medical,inPain)
+// #define VAR_TOURNIQUET        QEGVAR(medical,tourniquets)
+// #define VAR_FRACTURES         QEGVAR(medical,fractures)
+
+// #define VAR_BLOOD_PRESS       QEGVAR(medical,bloodPressure)
+// #define VAR_BLOOD_VOL         QEGVAR(medical,bloodVolume)
+// #define VAR_WOUND_BLEEDING    QEGVAR(medical,woundBleeding)
+// #define VAR_CRDC_ARRST        QEGVAR(medical,inCardiacArrest)
+// #define VAR_HEART_RATE        QEGVAR(medical,heartRate)
+// #define VAR_PAIN              QEGVAR(medical,pain)
+// #define VAR_PAIN_SUPP         QEGVAR(medical,painSuppress)
+// #define VAR_PERIPH_RES        QEGVAR(medical,peripheralResistance)
+// #define VAR_UNCON             "ACE_isUnconscious"
+// #define VAR_OPEN_WOUNDS       QEGVAR(medical,openWounds)
+// #define VAR_BANDAGED_WOUNDS   QEGVAR(medical,bandagedWounds)
+// #define VAR_STITCHED_WOUNDS   QEGVAR(medical,stitchedWounds)
+// // These variables track gradual adjustments (from medication, etc.)
+// #define VAR_MEDICATIONS       QEGVAR(medical,medications)
+// // These variables track the current state of status values above
+// #define VAR_HEMORRHAGE        QEGVAR(medical,hemorrhage)
+// #define VAR_IN_PAIN           QEGVAR(medical,inPain)
+// #define VAR_TOURNIQUET        QEGVAR(medical,tourniquets)
+// #define VAR_FRACTURES         QEGVAR(medical,fractures)

--- a/CrowsZA/functions/fn_activateZeusTextDisplay.sqf
+++ b/CrowsZA/functions/fn_activateZeusTextDisplay.sqf
@@ -12,6 +12,7 @@ Is called if ace is loaded, adds the toggle keybind and starts the display EH an
 
 // data array
 crowsZA_medical_status_players = [];
+crowsZA_zeusTextDisplay = false; // Not showing text by default
 
 // register CBA keybinding to toggle zeus-drawn text
 crowsZA_zeusTextDisplayKeybind = [

--- a/CrowsZA/functions/fn_activateZeusTextDisplay.sqf
+++ b/CrowsZA/functions/fn_activateZeusTextDisplay.sqf
@@ -1,0 +1,31 @@
+#include "common_defines.hpp"
+/*/////////////////////////////////////////////////
+Author: Crowdedlight
+			   
+File: fn_activateZeusTextDisplay.sqf
+Parameters: 
+Return: none
+
+Is called if ace is loaded, adds the toggle keybind and starts the display EH and ace medic status handler  
+
+*///////////////////////////////////////////////
+
+// data array
+crowsZA_medical_status_players = [];
+
+// register CBA keybinding to toggle zeus-drawn text
+crowsZA_zeusTextDisplayKeybind = [
+	["Crows Zeus Additions", "Zeus"],
+	"zeus_text_display", 
+	["Show help display text", "Shows text in zeus view for units. (medical status)"], 
+	{crowsZA_zeusTextDisplay = !crowsZA_zeusTextDisplay}, 
+	"", 
+	[DIK_H, [true, true, false]], // [DIK code, [Shift?, Ctrl?, Alt?]] => default: ctrl + shift + h
+	false] call CBA_fnc_addKeybind;
+
+// add ace medic update handler
+crowsZA_PFH_aceMedicTextUpdater = [crowsZA_fnc_aceMedicStatusHandler, 1] call CBA_fnc_addPerFrameHandler; 
+
+// add displayEH
+call FUNC(addZeusTextDisplayEH);
+

--- a/CrowsZA/functions/fn_addZeusTextDisplayEH.sqf
+++ b/CrowsZA/functions/fn_addZeusTextDisplayEH.sqf
@@ -1,0 +1,38 @@
+/*/////////////////////////////////////////////////
+Author: Crowdedlight
+			   
+File: fnc_addZeusTextDisplayEH.sqf
+Parameters: 
+Return: none
+
+Adds the drawEvent handlers to zeus to show the helper text for modules applied to players
+
+*///////////////////////////////////////////////
+
+// only if zeus, add draw3D handler for zeus-labels
+crowsZA_unit_icon_drawEH = addMissionEventHandler ["Draw3D", {
+	// if zeus display is null, exit. Only drawing when zeus display is open
+	if (isNull(findDisplay 312)) exitWith {};
+	if (isNull _x) exitWith {};
+	if (!crowsZA_zeusTextDisplay) exitWith {};
+
+	// cam position
+	//private _zeusPos = positionCameraToWorld [0,0,0];
+
+	// Medic 
+	{
+		// calculate distance from zeus camera to unit
+		// private _unit = _x select 0;
+		// private _dist = _zeusPos distance _unit;
+
+		// // if not within 500m, we don't draw it as the text does not scale and disappear with distance
+		// if (_dist > 500) then {continue;};
+		params["_woundNum", "_hr", "_bleedingWounds", "_inCRDC", "_inPain"];
+
+		// draw icon on relative pos 
+		private _txt = format["Wounds:%1, HR:%2)", _woundNum, _hr];
+		// offset: z: -0.5
+		private _pos = ASLToAGL getPosASL _unit;
+		drawIcon3D ["", [1,0,0,1], [_pos#0, _pos#1, _pos#2-0.5], 0, 0, 0, _txt, 1, 0.03, "RobotoCondensed", "center", false];
+	} forEach crowsZA_medical_status_players;
+}];

--- a/CrowsZA/functions/fn_zeusRegister.sqf
+++ b/CrowsZA/functions/fn_zeusRegister.sqf
@@ -85,6 +85,9 @@ private _wait = [player,_loadedMods] spawn
 		
 		if (_isAceLoaded) then {
 			_combinedArr = _combinedArr + _aceDependentModules;
+
+			// launch custom "handlers" for ace
+			call crowsZA_fnc_activateZeusTextDisplay;
 		};
 		
 		if (_isTFARLoaded) then {


### PR DESCRIPTION
Will add a toggle-able (keybind) function that displays a short "helper" text over players for zeus to get a quick idea how badly hurt they are. 

- [ ] Decide if it should only be shown in zeus-view (as now) or also when RC'ing units (Like player FPS)
- [ ] Figure out a good text representation for the data
- [ ] Figure out good visuals in text colour and size. (colour code based on severity? Like red: Cardiac Arrest, Yellow, bleeding, blue: wounds/in-pain, green: pristine)
- [ ] Figure out what data exactly gives the best info for zeus