### PR TITLE
Feature: remove/replace grenades/explosives from units' inventory

### DIFF
--- a/CrowsZA/cfgFunctions.hpp
+++ b/CrowsZA/cfgFunctions.hpp
@@ -48,6 +48,9 @@ class CrowsZA_addon
 
 		class setColour {};
 
+		class stripExplosives {};
+		class stripExplosivesZeus {};
+
 		class contextPasteLoadout {};
 		
 		class loadoutViewer {};

--- a/CrowsZA/functions/fn_stripExplosives.sqf
+++ b/CrowsZA/functions/fn_stripExplosives.sqf
@@ -4,7 +4,7 @@ Author: Landric
 File: fn_stripExplosives.sqf
 Parameters:
 	unit			- (unit)
-	smokeGrenades	- (int) 0: ignore, 1: remove, 2: replace
+	signalGrenades	- (int) 0: ignore, 1: remove, 2: replace
 	grenades		- (int) 0: ignore, 1: remove, 2: replace
 	launchers		- (int) 0: ignore, 1: remove
 	explosives		- (int) 0: ignore, 1: remove
@@ -12,32 +12,48 @@ Parameters:
 Return: none
 
 *///////////////////////////////////////////////
-params ["_unit", "_smokeGrenades", "_grenades", "_launchers", "_explosives"];
+params ["_unit", "_signalGrenades", "_grenades", "_launchers", "_explosives"];
 
 {
 	private _item = _x;
+	private _itemParents = [ configFile >> "CfgMagazines" >> _item, true ] call BIS_fnc_returnParents;
 
-	if(_smokeGrenades > 0 && (crowsZA_common_smokeGrenades findIf { [_x, _item] call BIS_fnc_inString }) != -1) then {
+	// NOTE: This includes chemlights and IR strobes
+	if(_signalGrenades > 0 && (
+		("SmokeShell" in _itemParents) ||
+		("B_IR_Grenade" in _itemParents) ||
+		("O_IR_Grenade" in _itemParents) ||
+		("I_IR_Grenade" in _itemParents) ||
+		("I_E_IR_Grenade" in _itemParents) ||
+		("O_R_IR_Grenade" in _itemParents))
+	) then {
 		_unit removeMagazineGlobal _x;
-		if(_smokeGrenades == 2) then {
+		if(_signalGrenades == 2) then {
 			_unit addMagazineGlobal "SmokeShell";
 		};
 	};
 
-	if(_grenades > 0 && (crowsZA_common_grenades findIf { [_x, _item] call BIS_fnc_inString }) != -1) then {
+	if(_grenades > 0 && ( ("MiniGrenade" in _itemParents) || ("HandGrenade" in _itemParents) )) then {
 		_unit removeMagazineGlobal _x;
 		if(_grenades == 2) then {
 			_unit addMagazineGlobal "MiniGrenade";
 		};
 	};
 
-	if(_explosives > 0 && (crowsZA_common_explosives findIf { [_x, _item] call BIS_fnc_inString }) != -1) then {
+	if(_explosives > 0 && (
+		("ATMine_Range_Mag" in _itemParents) ||
+		("SatchelCharge_Remote_Mag" in _itemParents) ||
+		("ACE_SatchelCharge_Remote_Mag_Throwable" in _itemParents) ||
+		("ClaymoreDirectionalMine_Remote_Mag" in _itemParents))
+	) then {
 		_unit removeMagazineGlobal _x;
 	};
+
 } forEach magazines _unit;
 
 if(_launchers > 0) then {
-	// TODO: remove launcher ammo?
-	// (even if the unit doesn't have a launcher, e.g. AT Assistants)
 	_unit removeWeaponGlobal (secondaryWeapon _unit);
+
+	// TODO: also remove launcher ammo?
+	// (even if the unit doesn't have a launcher, e.g. AT Assistants)
 };

--- a/CrowsZA/functions/fn_stripExplosives.sqf
+++ b/CrowsZA/functions/fn_stripExplosives.sqf
@@ -2,7 +2,13 @@
 Author: Landric
 			   
 File: fn_stripExplosives.sqf
-Parameters: _unit, _smokeGrenades, _grenades, _launchers, _explosives
+Parameters:
+	unit			- (unit)
+	smokeGrenades	- (int) 0: ignore, 1: remove, 2: replace
+	grenades		- (int) 0: ignore, 1: remove, 2: replace
+	launchers		- (int) 0: ignore, 1: remove
+	explosives		- (int) 0: ignore, 1: remove
+
 Return: none
 
 *///////////////////////////////////////////////
@@ -31,6 +37,7 @@ params ["_unit", "_smokeGrenades", "_grenades", "_launchers", "_explosives"];
 } forEach magazines _unit;
 
 if(_launchers > 0) then {
-	// TODO: remove launcher ammo (even if the unit doesn't have a launcher, e.g. AT Assistants)
+	// TODO: remove launcher ammo?
+	// (even if the unit doesn't have a launcher, e.g. AT Assistants)
 	_unit removeWeaponGlobal (secondaryWeapon _unit);
 };

--- a/CrowsZA/functions/fn_stripExplosives.sqf
+++ b/CrowsZA/functions/fn_stripExplosives.sqf
@@ -1,0 +1,36 @@
+/*/////////////////////////////////////////////////
+Author: Landric
+			   
+File: fn_stripExplosives.sqf
+Parameters: _unit, _smokeGrenades, _grenades, _launchers, _explosives
+Return: none
+
+*///////////////////////////////////////////////
+params ["_unit", "_smokeGrenades", "_grenades", "_launchers", "_explosives"];
+
+{
+	private _item = _x;
+
+	if(_smokeGrenades > 0 && (crowsZA_common_smokeGrenades findIf { [_x, _item] call BIS_fnc_inString }) != -1) then {
+		_unit removeMagazineGlobal _x;
+		if(_smokeGrenades == 2) then {
+			_unit addMagazineGlobal "SmokeShell";
+		};
+	};
+
+	if(_grenades > 0 && (crowsZA_common_grenades findIf { [_x, _item] call BIS_fnc_inString }) != -1) then {
+		_unit removeMagazineGlobal _x;
+		if(_grenades == 2) then {
+			_unit addMagazineGlobal "MiniGrenade";
+		};
+	};
+
+	if(_explosives > 0 && (crowsZA_common_explosives findIf { [_x, _item] call BIS_fnc_inString }) != -1) then {
+		_unit removeMagazineGlobal _x;
+	};
+} forEach magazines _unit;
+
+if(_launchers > 0) then {
+	// TODO: remove launcher ammo (even if the unit doesn't have a launcher, e.g. AT Assistants)
+	_unit removeWeaponGlobal (secondaryWeapon _unit);
+};

--- a/CrowsZA/functions/fn_stripExplosivesZeus.sqf
+++ b/CrowsZA/functions/fn_stripExplosivesZeus.sqf
@@ -1,0 +1,90 @@
+/*/////////////////////////////////////////////////
+Author: Landric
+			   
+File: fn_stripExplosivesZeus.sqf
+Parameters: pos, unit
+Return: none
+
+*///////////////////////////////////////////////
+params [["_pos",[0,0,0],[[]],3], ["_unit",objNull,[objNull]]];
+
+private _onSide =
+{
+	params ["_dialogResult","_in"];
+	_dialogResult params [["_side", east, [east]], ["_ignorePlayers", true, [true]], ["_smokeGrenades", 2, [2]], ["_grenades", 0, [0]], "_launchers", "_explosives"];
+	_in params [["_pos",[0,0,0],[[]],3], "_unit"];
+
+	//log
+	private _items = "items"; //[];
+	// if(_grenades == 1) then { _items pushBack "smoke grenades"; };
+	// if(_grenades == 2) then { _items pushBack "explosive grenades"; };
+	// if(_grenades == 3) then { _items append ["smoke grenades", "explosive grenades"]; };
+	diag_log format ["crowsZA-stripAIExplosives: Stripping %1 from %2 side", _items, _side];
+
+	[_side, _ignorePlayers, _smokeGrenades, _grenades, _launchers, _explosives] spawn {
+		params["_side", "_ignorePlayers", "_smokeGrenades", "_grenades", "_launchers", "_explosives"];
+		{
+			if(side _x == _side && (!(isPlayer _x) || !_ignorePlayers)) then {
+				[_x, _smokeGrenades, _grenades, _launchers, _explosives] call crowsZA_fnc_stripExplosives;
+			};
+			sleep 0.01;
+		} foreach allUnits;
+	};
+};
+
+private _onUnit =
+{
+	params ["_dialogResult","_in"];
+	_dialogResult params [["_group", true, [true]], ["_smokeGrenades", 2, [2]], ["_grenades", 0, [0]], ["_launchers", 0, [0]], ["_explosives", 0, [0]]];
+	_in params [["_pos",[0,0,0],[[]],3], "_unit"];
+
+	//log
+	private _items = "items";
+	private _entity = switch(_group) do {
+		case true: { format ["group %1", group _unit] };
+		case false: { format ["unit %1", _unit] };
+	};
+	diag_log format ["crowsZA-stripAIExplosives: Stripping %1 from %2", _items, _entity];
+
+	private _units = switch(_group) do {
+		case true: { units (group _unit) };
+		default { [_unit] };
+	};
+	
+	[_units, _smokeGrenades, _grenades, _launchers, _explosives] spawn {
+		params["_units", "_smokeGrenades", "_grenades", "_launchers", "_explosives"];
+		{
+			[_x, _smokeGrenades, _grenades, _launchers, _explosives] call crowsZA_fnc_stripExplosives;
+			sleep 0.01;
+		} foreach _units;
+	};
+};
+
+
+private _controls = [
+		["SIDES", "Side", east],
+		["CHECKBOX", "Ignore players", true],
+		["CHECKBOX", ["Whole Group", "Remove items from this unit's group"], true],
+		["TOOLBOX", ["Smoke Grenades", """Replace"" will replace each instance with a base-game white smoke"], [2, 1, 3, ["Ignore", "Remove", "Replace"]]],
+		["TOOLBOX", ["Explosive Grenades", """Replace"" will replace each instance with a base-game RGN grenade"], [0, 1, 3, ["Ignore", "Remove", "Replace"]]],
+		["TOOLBOX", "Launchers", [0, 1, 2, ["Ignore", "Remove"]]],
+		["TOOLBOX", "Explosives", [0, 1, 2, ["Ignore", "Remove"]]]
+];
+
+private "_onConfirm";
+if(isNull _unit) then {
+	_controls deleteAt 2;
+	_onConfirm =_onSide;
+}
+else{
+	_controls deleteRange [0, 2];
+	_onConfirm =_onUnit;
+};
+
+[
+	"Remove Explosives",
+	_controls,
+	_onConfirm,
+	{},
+	_this
+] call zen_dialog_fnc_create;

--- a/CrowsZA/functions/fn_stripExplosivesZeus.sqf
+++ b/CrowsZA/functions/fn_stripExplosivesZeus.sqf
@@ -11,22 +11,22 @@ params [["_pos",[0,0,0],[[]],3], ["_unit",objNull,[objNull]]];
 private _onSide =
 {
 	params ["_dialogResult","_in"];
-	_dialogResult params [["_side", east, [east]], ["_ignorePlayers", true, [true]], ["_smokeGrenades", 2, [2]], ["_grenades", 0, [0]], "_launchers", "_explosives"];
+	_dialogResult params [["_side", east, [east]], ["_ignorePlayers", true, [true]], ["_signalGrenades", 2, [2]], ["_grenades", 0, [0]], "_launchers", "_explosives"];
 	_in params [["_pos",[0,0,0],[[]],3], "_unit"];
 
 	//log
 	private _items = [];
-	if(_smokeGrenades > 0) then { _items pushBack "smoke grenades"; };
+	if(_signalGrenades > 0) then { _items pushBack "smoke grenades"; };
 	if(_grenades > 0) then { _items pushBack "explosive grenades"; };
 	if(_launchers > 0) then { _items pushBack "launchers"; };
 	if(_explosives > 0) then { _items pushBack "explosives"; };
 	diag_log format ["crowsZA-stripExplosives: Stripping %1 from %2 side", _items joinString ", ", _side];
 
-	[_side, _ignorePlayers, _smokeGrenades, _grenades, _launchers, _explosives] spawn {
-		params["_side", "_ignorePlayers", "_smokeGrenades", "_grenades", "_launchers", "_explosives"];
+	[_side, _ignorePlayers, _signalGrenades, _grenades, _launchers, _explosives] spawn {
+		params["_side", "_ignorePlayers", "_signalGrenades", "_grenades", "_launchers", "_explosives"];
 		{
 			if(side _x == _side && (!(isPlayer _x) || !_ignorePlayers)) then {
-				[_x, _smokeGrenades, _grenades, _launchers, _explosives] call crowsZA_fnc_stripExplosives;
+				[_x, _signalGrenades, _grenades, _launchers, _explosives] call crowsZA_fnc_stripExplosives;
 			};
 			sleep 0.01;
 		} foreach allUnits;
@@ -36,12 +36,12 @@ private _onSide =
 private _onUnit =
 {
 	params ["_dialogResult","_in"];
-	_dialogResult params [["_group", true, [true]], ["_smokeGrenades", 2, [2]], ["_grenades", 0, [0]], ["_launchers", 0, [0]], ["_explosives", 0, [0]]];
+	_dialogResult params [["_group", true, [true]], ["_signalGrenades", 2, [2]], ["_grenades", 0, [0]], ["_launchers", 0, [0]], ["_explosives", 0, [0]]];
 	_in params [["_pos",[0,0,0],[[]],3], "_unit"];
 
 	//log
 	private _items = [];
-	if(_smokeGrenades > 0) then { _items pushBack "smoke grenades"; };
+	if(_signalGrenades > 0) then { _items pushBack "smoke grenades"; };
 	if(_grenades > 0) then { _items pushBack "explosive grenades"; };
 	if(_launchers > 0) then { _items pushBack "launchers"; };
 	if(_explosives > 0) then { _items pushBack "explosives"; };
@@ -56,10 +56,10 @@ private _onUnit =
 		default { [_unit] };
 	};
 	
-	[_units, _smokeGrenades, _grenades, _launchers, _explosives] spawn {
-		params["_units", "_smokeGrenades", "_grenades", "_launchers", "_explosives"];
+	[_units, _signalGrenades, _grenades, _launchers, _explosives] spawn {
+		params["_units", "_signalGrenades", "_grenades", "_launchers", "_explosives"];
 		{
-			[_x, _smokeGrenades, _grenades, _launchers, _explosives] call crowsZA_fnc_stripExplosives;
+			[_x, _signalGrenades, _grenades, _launchers, _explosives] call crowsZA_fnc_stripExplosives;
 			sleep 0.01;
 		} foreach _units;
 	};
@@ -70,7 +70,7 @@ private _controls = [
 		["SIDES", "Side", east],
 		["CHECKBOX", "Ignore players", true],
 		["CHECKBOX", ["Whole Group", "Remove items from this unit's group"], true],
-		["TOOLBOX", ["Smoke Grenades", """Replace"" will replace each instance with a base-game white smoke"], [2, 1, 3, ["Ignore", "Remove", "Replace"]]],
+		["TOOLBOX", ["Signal Grenades", """Replace"" will replace each instance with a base-game white smoke"], [2, 1, 3, ["Ignore", "Remove", "Replace"]]],
 		["TOOLBOX", ["Explosive Grenades", """Replace"" will replace each instance with a base-game RGN grenade"], [0, 1, 3, ["Ignore", "Remove", "Replace"]]],
 		["TOOLBOX", "Launchers", [0, 1, 2, ["Ignore", "Remove"]]],
 		["TOOLBOX", "Explosives", [0, 1, 2, ["Ignore", "Remove"]]]

--- a/CrowsZA/functions/fn_stripExplosivesZeus.sqf
+++ b/CrowsZA/functions/fn_stripExplosivesZeus.sqf
@@ -15,11 +15,12 @@ private _onSide =
 	_in params [["_pos",[0,0,0],[[]],3], "_unit"];
 
 	//log
-	private _items = "items"; //[];
-	// if(_grenades == 1) then { _items pushBack "smoke grenades"; };
-	// if(_grenades == 2) then { _items pushBack "explosive grenades"; };
-	// if(_grenades == 3) then { _items append ["smoke grenades", "explosive grenades"]; };
-	diag_log format ["crowsZA-stripAIExplosives: Stripping %1 from %2 side", _items, _side];
+	private _items = [];
+	if(_smokeGrenades > 0) then { _items pushBack "smoke grenades"; };
+	if(_grenades > 0) then { _items pushBack "explosive grenades"; };
+	if(_launchers > 0) then { _items pushBack "launchers"; };
+	if(_explosives > 0) then { _items pushBack "explosives"; };
+	diag_log format ["crowsZA-stripExplosives: Stripping %1 from %2 side", _items joinString ", ", _side];
 
 	[_side, _ignorePlayers, _smokeGrenades, _grenades, _launchers, _explosives] spawn {
 		params["_side", "_ignorePlayers", "_smokeGrenades", "_grenades", "_launchers", "_explosives"];
@@ -39,12 +40,16 @@ private _onUnit =
 	_in params [["_pos",[0,0,0],[[]],3], "_unit"];
 
 	//log
-	private _items = "items";
+	private _items = [];
+	if(_smokeGrenades > 0) then { _items pushBack "smoke grenades"; };
+	if(_grenades > 0) then { _items pushBack "explosive grenades"; };
+	if(_launchers > 0) then { _items pushBack "launchers"; };
+	if(_explosives > 0) then { _items pushBack "explosives"; };
 	private _entity = switch(_group) do {
 		case true: { format ["group %1", group _unit] };
 		case false: { format ["unit %1", _unit] };
 	};
-	diag_log format ["crowsZA-stripAIExplosives: Stripping %1 from %2", _items, _entity];
+	diag_log format ["crowsZA-stripExplosives: Stripping %1 from %2", _items, _entity];
 
 	private _units = switch(_group) do {
 		case true: { units (group _unit) };

--- a/CrowsZA/functions/fn_zeusRegister.sqf
+++ b/CrowsZA/functions/fn_zeusRegister.sqf
@@ -24,6 +24,27 @@ crowsZA_animalFollowList = [];
 publicVariable "crowsZA_animalFollowList";
 crowsZA_common_selectPositionActive = false;
 
+// Collect a list of various explosives, for use in fn_stripExplosives
+// (so that the list isn't created for every unit)
+
+// NOTE: This includes chemlights
+crowsZA_common_smokeGrenades = (("inheritsFrom _x == (configFile >> 'CfgMagazines' >> 'SmokeShell')" configClasses (configFile >> 'CfgMagazines')) apply { configName _x }) + ['SmokeShell'];
+// NOTE: This includes flares
+crowsZA_common_grenades = ((
+		(
+			("inheritsFrom _x == (configFile >> 'CfgMagazines' >> 'MiniGrenade')" configClasses (configFile >> 'CfgMagazines')) +
+			("inheritsFrom _x == (configFile >> 'CfgMagazines' >> 'HandGrenade')" configClasses (configFile >> 'CfgMagazines'))
+		) apply { configName _x }
+	) - crowsZA_common_smokeGrenades) + ['MiniGrenade', 'HandGrenade'];
+// TODO: ACE_SatchelCharge_Remote_Mag_Throwable should go with "grenades" instead?
+crowsZA_common_explosives =  ((
+		("inheritsFrom _x == (configFile >> 'CfgMagazines' >> 'ATMine_Range_Mag')" configClasses (configFile >> 'CfgMagazines')) +
+		("inheritsFrom _x == (configFile >> 'CfgMagazines' >> 'SatchelCharge_Remote_Mag')" configClasses (configFile >> 'CfgMagazines')) +
+		("inheritsFrom _x == (configFile >> 'CfgMagazines' >> 'ACE_SatchelCharge_Remote_Mag_Throwable')" configClasses (configFile >> 'CfgMagazines')) +
+		("inheritsFrom _x == (configFile >> 'CfgMagazines' >> 'ClaymoreDirectionalMine_Remote_Mag')" configClasses (configFile >> 'CfgMagazines'))
+	) apply { configName _x }) + ['ATMine_Range_Mag', 'SatchelCharge_Remote_Mag', 'ACE_SatchelCharge_Remote_Mag_Throwable', 'ClaymoreDirectionalMine_Remote_Mag'];
+
+
 private _loadedMods = getLoadedModsInfo;
 //spawn script to register zen modules
 private _wait = [player,_loadedMods] spawn
@@ -77,7 +98,8 @@ private _wait = [player,_loadedMods] spawn
 			["DrawBuild",{_this call crowsZA_fnc_drawBuildZeus}, "\CrowsZA\data\drawbuild.paa"],
 			["Fire Support",{_this call crowsZA_fnc_fireSupport}, "\x\zen\addons\modules\ui\target_ca.paa"],
 			["Resupply Player Loadouts",{_this call crowsZA_fnc_resupplyPlayerLoadouts}, "\CrowsZA\data\resupplyplayerloadout.paa"],
-			["Remove Radio/Bino",{_this call crowsZA_fnc_removeRadioBino}, "\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\call_ca.paa"]
+			["Remove Radio/Bino",{_this call crowsZA_fnc_removeRadioBino}, "\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\call_ca.paa"],
+			["Strip Explosives",{_this call crowsZA_fnc_stripExplosivesZeus}, "\a3\ui_f\data\igui\cfg\simpletasks\types\destroy_ca.paa"]			
 		];
 		private _tfarModules = [
 			["Set TFAR Vehicle Radio Side",{_this call crowsZA_fnc_tfarSetVehicleSide}, "\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\call_ca.paa"]


### PR DESCRIPTION
Addresses #53 - provides a module to remove grenades, launchers, and/or explosives from a given side, group, or unit.

Grenades (both smoke and explosives) can be replaced by their vanilla counterparts.

Currently does *not* set a variable on units the module has been applied to, as performance impact seems minimal.

Possible expansions: could also add an option for removing UGL ammo (and/or UGLs themselves)