### PR TITLE
Updates to drawBuild

### DIFF
--- a/CrowsZA/config.cpp
+++ b/CrowsZA/config.cpp
@@ -19,15 +19,9 @@ class CfgPatches
 		 };
 		author = "Crowdedlight";
 		authorUrl = "https://forums.bohemia.net/profile/1173289-crowdedlight/";
-<<<<<<< HEAD
-		version = 1.10.2;
-		versionStr = "1.10.2";
-		versionAr[] = {1,10,2};
-=======
 		version = 1.10.3;
 		versionStr = "1.10.3";
 		versionAr[] = {1,10,3};
->>>>>>> release/1.10.3
 	};
 };
 

--- a/CrowsZA/functions/fn_drawBuild.sqf
+++ b/CrowsZA/functions/fn_drawBuild.sqf
@@ -41,6 +41,13 @@ switch(_objectName) do {
 		_spawnObjectLengthOffset = 0.7;
 		_spawnDirOffset = 90; //90deg offset
 	};
+	// tall sandbags
+	case "Land_SandbagBarricade_01_F":
+	{
+		_spawnObjectLength = 1.7;
+		_spawnObjectLengthOffset = 1.7;
+		_spawnDirOffset = 90; //90deg offset
+	};
 	// trench
 	case "fort_envelopebig": //only exists if grad trenches is on the server
 	{
@@ -125,6 +132,13 @@ switch(_objectName) do {
 		_spawnObjectLengthOffset = 1.2;
 		_spawnDirOffset = 90; //90deg offset
 	};
+	//power cables
+	case "PowerCable_01_StraightLong_F":
+	{
+		_spawnObjectLength = 5.02368;
+		_spawnObjectLengthOffset = 2.49;
+		_spawnDirOffset = 0; //no offset
+	};
 };
 
 // calculate distance between points to know amount of hesco to cover the length - https://community.bistudio.com/wiki/vectorDistance
@@ -146,7 +160,7 @@ private _distMove = _spawnObjectLength;
 // array of spawned objects 
 private _allObjects = [];
 
-// loop over the amount of hesco needed to be placed (distance calculation)
+// loop over the amount of object needed to be placed (distance calculation)
 for "_i" from 1 to _iterations do {
 	// increment distance - https://community.bistudio.com/wiki/getPos
 	// if first position, we only move the offset from clicked position, for the rest we move position and offset.
@@ -155,17 +169,15 @@ for "_i" from 1 to _iterations do {
 	if (_i == 1) then {
 		_nextPos = _tempPos getPos [_spawnObjectLengthOffset, _direction];
 	} else {
-		_nextPos = _tempPos getPos [_distMove, _direction]; 	
+		_nextPos = _tempPos getPos [_distMove, _direction];
 	};
 
-	// diag_log format["nextpos: %1", _nextPos];
-
-	// spawn hesco - https://community.bistudio.com/wiki/createVehicle
+	// spawn object - https://community.bistudio.com/wiki/createVehicle
 	_object = createVehicle [_objectName, _nextPos, [], 0, "CAN_COLLIDE"];
 
 	// disable simulation if selected - Executed on server
 	if (!_enableSim) then {
-		[_object, false] remoteExec ["enableSimulationGlobal", 2];
+		_object enableSimulationGlobal false;
 	};
 
 	// disable damage if chosen - If we see issues with this in future, consider setting owner to server, before disabling damage as the owner shouldn't change short of server crash... and then it doesnt matter

--- a/CrowsZA/functions/fn_drawBuild.sqf
+++ b/CrowsZA/functions/fn_drawBuild.sqf
@@ -175,6 +175,12 @@ for "_i" from 1 to _iterations do {
 	// spawn object - https://community.bistudio.com/wiki/createVehicle
 	_object = createVehicle [_objectName, _nextPos, [], 0, "CAN_COLLIDE"];
 
+	// Align to highest surface (via killzone_kid at https://community.bistudio.com/wiki/Position#PositionAGLS)
+	_nextPos set [2, worldSize];
+	_object setPosASL _nextPos;
+	_nextPos set [2, vectorMagnitude (_nextPos vectorDiff getPosVisual _object)];
+	_object setPosASL _nextPos;
+
 	// disable simulation if selected - Executed on server
 	if (!_enableSim) then {
 		_object enableSimulationGlobal false;
@@ -188,8 +194,11 @@ for "_i" from 1 to _iterations do {
 	// rotate it - https://community.bistudio.com/wiki/setVectorDir 
 	_object setDir _direction + _spawnDirOffset; //is individual offset
 
+	_object setVectorUp surfaceNormal position _object;
+
 	// set same position again to sync rotation across clients (Also snaps it to ground level better after rotation)
-	_object setPos (getPos _object);
+	//_object setPos (getPos _object);
+	_object setPosWorld getPosWorld _object;
 
 	// add to array to make zeus editable. Doing like so to only send one server event and not one per spawned element, more effecient. 	
 	_allObjects pushBack _object;

--- a/CrowsZA/functions/fn_drawBuild.sqf
+++ b/CrowsZA/functions/fn_drawBuild.sqf
@@ -154,7 +154,7 @@ switch(_objectName) do {
 		_spawnObjectLength = 40;
 		_spawnObjectLengthOffset = 20;
 		_spawnDirOffset = 0; //no offset
-		_spawnObjectHeight = 9;
+		_spawnObjectHeight = 8.9;
 	};
 };
 

--- a/CrowsZA/functions/fn_drawBuildZeus.sqf
+++ b/CrowsZA/functions/fn_drawBuildZeus.sqf
@@ -14,6 +14,8 @@ Starts the selection handler to select multiple points for you to draw
 
 params [["_pos",[0,0,0],[[]],3], ["_unit",objNull,[objNull]]];
 
+crowsZA_drawbuild_lastPole = objNull;
+
 //create display 
 if (!createDialog "crowsZA_drawbuild_display") exitWith {["Failed to open drawbuild dialog"] call crowsZA_fnc_showHint};
 
@@ -49,7 +51,9 @@ private _arrOptions = [
 	"Land_Razorwire_F",						//razor wire
 
 	//misc.
-	"PowerCable_01_StraightLong_F"			//power cable
+	"PowerCable_01_StraightLong_F",			//power cable
+	"Land_PowerLine_03_pole_F", 			//concrete overhead line
+	"Land_PowerLine_02_pole_small_F"		//wood overhead line
 ];
 
 // only add grad trenches if that mod is loaded

--- a/CrowsZA/functions/fn_drawBuildZeus.sqf
+++ b/CrowsZA/functions/fn_drawBuildZeus.sqf
@@ -31,6 +31,7 @@ private _arrOptions = [
 	"Land_HBarrier_3_F",					//hesco default
 	"Land_HBarrier_Big_F",					//big hesco default
 	"Land_BagFence_Short_F",				//sandbag wall - default
+	"Land_SandbagBarricade_01_F",			//tall sandbags
 	"Land_TyreBarrier_01_line_x4_F",		//tire wall
 	"Land_ConcreteWall_01_m_4m_F", 			//concrete wall
 	
@@ -45,7 +46,10 @@ private _arrOptions = [
 	"Land_Hedge_01_s_2m_F",					//grass hedge
 	"Land_NetFence_02_m_4m_F",				//net fence
 	"Land_New_WiredFence_5m_F",				//wire fence
-	"Land_Razorwire_F"						//razor wire
+	"Land_Razorwire_F",						//razor wire
+
+	//misc.
+	"PowerCable_01_StraightLong_F"			//power cable
 ];
 
 // only add grad trenches if that mod is loaded

--- a/CrowsZA/ui/drawbuildGui.hpp
+++ b/CrowsZA/ui/drawbuildGui.hpp
@@ -25,13 +25,14 @@ class crowsZA_drawbuild_display {
         };
         class Content: RscControlsGroupNoScrollbars {
             idc = IDC_CONTENT;
-            h = POS_H(11);
+            h = POS_H(13.5);
             x = POS_X(12);
             w = POS_W(14);
             class controls {
                 class grid1: RscActivePicture {
                     idc = IDC_ICON_GRID_FIRST;
-                    text = "\A3\EditorPreviews_F\Data\CfgVehicles\Land_BagFence_Short_F.jpg";
+                    //text = "\A3\EditorPreviews_F\Data\CfgVehicles\Land_BagFence_Short_F.jpg";
+                    text = ""; // Don't display a preview image if there's no content for the grid
                     color[] = {1,1,1,0.8}; //change from 0.5 alpha to not be too dark but still show when hovered
                     tooltip = "";
                     x = 0;
@@ -99,11 +100,33 @@ class crowsZA_drawbuild_display {
                     idc = IDC_ICON_GRID_FIRST + 14;
                     x = POS_W(12);
                 };
+                // row 4
+                class row4: grid1 {
+                    idc = IDC_ICON_GRID_FIRST + 15;
+                    x = 0;
+                    y = POS_H(8);
+                };
+                class grid17: row4 {
+                    idc = IDC_ICON_GRID_FIRST + 16;
+                    x = POS_W(3);
+                };
+                class grid18: row4 {
+                    idc = IDC_ICON_GRID_FIRST + 17;
+                    x = POS_W(6);
+                };
+                class grid19: row4 {
+                    idc = IDC_ICON_GRID_FIRST + 18;
+                    x = POS_W(9);
+                };
+                class grid20: row4 {
+                    idc = IDC_ICON_GRID_FIRST + 19;
+                    x = POS_W(12);
+                };
                 // bottom rows for toggle enables, simulation
                 class cbSimulation: RscCheckBox {
                     idc = IDC_CHECKBOX_SIMULATION;
                     x = 0;
-                    y = POS_H(8);
+                    y = POS_H(10.5);
                     w = POS_W(1);
                     h = POS_H(1);
                     soundClick[] = {"\a3\ui_f\data\sound\rscbutton\soundclick", 0.09, 1};
@@ -115,7 +138,7 @@ class crowsZA_drawbuild_display {
                 class lblSimulation: RscText {
                     idc = -1;
                     x = POS_W(1);
-                    y = POS_H(8);
+                    y = POS_H(10.5);
                     w = POS_W(10);
                     h = POS_H(1);
                     // colorBackground[] = {0, 0, 0, 0.7};
@@ -124,11 +147,11 @@ class crowsZA_drawbuild_display {
                 // damage
                 class cbDamage: cbSimulation {
                     idc = IDC_CHECKBOX_DAMAGE;
-                    y = POS_H(9.5);
+                    y = POS_H(12);
                     checked = 0; //default to be disabled
                 };
                 class lblDamage: lblSimulation {
-                    y = POS_H(9.5);
+                    y = POS_H(12);
                     text = "Enable Damage";
                 };        
             };


### PR DESCRIPTION
### Features
* Add "tall" sandbags
* Add ground-laid cables
* Add overhead cables
* Add extra row to UI
* Remove preview images for unused UI grids
* Call enableSimulationGlobal locally now
* "Walkable" objects (e.g. hescos) can be stacked
* Objects can now be placed on buildings (with some degree of success)

### Known Issues
* Ground cables occasionally float over/are occluded by terrain (particularly on steep slopes)
    * Workaround: zeus can Alt+drag to snap back to terrain
* Positioning objects accurately on top of buildings is difficult depending on camera angle
* Use of [setWorldPos instead of setPos](https://github.com/Landric/Crows-Zeus-Additions/blob/1478c1e4a2e028302b1373fac7d3dafe555b45cc/CrowsZA/functions/fn_drawBuild.sqf#L201) is untested on server - unsure if it still syncs rotation to all clients
* Distance between overhead-cable poles, and slack in the cables, may need to be tweaked for 'realism'