### PR TITLE
Update spawnIEDClutter

### DIFF
--- a/CrowsZA/functions/fn_spawnIEDClutter.sqf
+++ b/CrowsZA/functions/fn_spawnIEDClutter.sqf
@@ -179,26 +179,36 @@ for "_i" from 1 to _clutterAmount do {
  Place IED(s)
 /*/////////////////////////////////////////////////
 
-private _ieds = [
-	"ACE_IEDLandBig_Range_Ammo",
-	"ACE_IEDUrbanBig_Range_Ammo",
-	"ACE_IEDLandSmall_Range_Ammo",
-	"ACE_IEDUrbanSmall_Range_Ammo"
-];
+private _ieds = if(crowsZA_common_aceModLoaded) then { 
+	[
+		"ACE_IEDLandBig_Range_Ammo",
+		"ACE_IEDUrbanBig_Range_Ammo",
+		"ACE_IEDLandSmall_Range_Ammo",
+		"ACE_IEDUrbanSmall_Range_Ammo"
+	]
+} else {
+	[
+		"ModuleExplosive_IEDLandBig_F",
+		"ModuleExplosive_IEDUrbanBig_F",
+		"ModuleExplosive_IEDLandSmall_F",
+		"ModuleExplosive_IEDUrbanSmall_F"
+	]
+};
+
 
 if(_iedSize == 0) then {
-	_ieds = _ieds - ["ACE_IEDLandBig_Range_Ammo","ACE_IEDUrbanBig_Range_Ammo"];
+	_ieds = _ieds - ["ACE_IEDLandBig_Range_Ammo","ACE_IEDUrbanBig_Range_Ammo", "ModuleExplosive_IEDLandBig_F", "ModuleExplosive_IEDUrbanBig_F"];
 };
 if(_iedSize == 1) then {
-	_ieds = _ieds - ["ACE_IEDLandSmall_Range_Ammo","ACE_IEDUrbanSmall_Range_Ammo"];
+	_ieds = _ieds - ["ACE_IEDLandSmall_Range_Ammo","ACE_IEDUrbanSmall_Range_Ammo","ModuleExplosive_IEDLandSmall_F","ModuleExplosive_IEDUrbanSmall_F"];
 };
 
 
 if(_iedType == 0) then {
-	_ieds = _ieds - ["ACE_IEDLandBig_Range_Ammo","ACE_IEDLandSmall_Range_Ammo"];
+	_ieds = _ieds - ["ACE_IEDLandBig_Range_Ammo","ACE_IEDLandSmall_Range_Ammo", "ModuleExplosive_IEDLandBig_F","ModuleExplosive_IEDLandSmall_F"];
 };
 if(_iedType == 1) then {
-	_ieds = _ieds - ["ACE_IEDUrbanBig_Range_Ammo","ACE_IEDUrbanSmall_Range_Ammo"];
+	_ieds = _ieds - ["ACE_IEDUrbanBig_Range_Ammo","ACE_IEDUrbanSmall_Range_Ammo","ModuleExplosive_IEDUrbanBig_F","ModuleExplosive_IEDUrbanSmall_F"];
 };
 
 
@@ -214,7 +224,8 @@ for "_i" from 1 to _iedAmount do {
 	// If ied type is set to clutter (or random, with a 0.33 chance)
 	// place an extra piece of clutter, and hide an invisible ied beneath it;
 	// it should still be able to be detonated and defused as normal
-	if(_iedType == 2 || (_iedType == 3 && (random 1) < 0.33)) then {
+	// (Non-ace ieds can't have their model hidden, so can't be disguised as clutter)
+	if(crowsZA_common_aceModLoaded && (_iedType == 2 || (_iedType == 3 && (random 1) < 0.33))) then {
 		_clutter = (selectRandom _smallClutter) createVehicle _safePos;
 		_clutter setDir (random 360);
 		_clutter enableSimulationGlobal false;
@@ -225,6 +236,40 @@ for "_i" from 1 to _iedAmount do {
 	} else {
 		_ied = _ied createVehicle _safePos;
 		_ied setDir (random 360);
+	};
+
+	// If ace isn't loaded, mimic an ace pressure-plate ied
+	if(!crowsZA_common_aceModLoaded) then {
+		private _trigger = createTrigger ["EmptyDetector", getPos _ied, false];
+		private _radius = 2;
+		_trigger setTriggerArea [_radius, _radius, 0, false];
+		_trigger setTriggerActivation ["ANY", "PRESENT", true];
+
+		_trigger setVariable ["_ied", _ied];
+		_ied setVariable ["_trigger", _trigger];
+
+		private _condition = "this && (thisList findIf { !((stance _x) == ""PRONE"" || (stance _x) == """") } > -1);";
+
+		private _activation = "
+		(thisTrigger getVariable ""_ied"") setDamage 1;
+		deletevehicle thisTrigger;
+		";
+
+		_trigger setTriggerStatements [
+			_condition,
+			_activation,
+			""
+		];
+
+		_ied addEventHandler ["Deleted", {
+			params ["_entity"];
+			deleteVehicle (_entity getVariable "_trigger");
+		}];
+
+		_ied addEventHandler ["Killed", {
+			params ["_unit", "_killer", "_instigator", "_useEffects"];
+			deleteVehicle (_unit getVariable "_trigger");
+		}];
 	};
 
 	// TODO: This doesn't seem to work for (armed) explosives

--- a/CrowsZA/functions/fn_spawnIEDClutterZeus.sqf
+++ b/CrowsZA/functions/fn_spawnIEDClutterZeus.sqf
@@ -30,6 +30,15 @@ private _onConfirm =
 	[_pos, _radius, _density, _maxClutterSize, _iedSize, _iedType, _iedAmount] call crowsZA_fnc_spawnIEDClutter;
 		
 };
+
+
+// Non-ace ieds can't have their model hidden, so can't be disguised as clutter
+private _iedTypeToolbox = if(crowsZA_common_aceModLoaded) then {
+	["TOOLBOX", ["IED Type", """Clutter"" transforms a random object of clutter into an IED"], [0, 1, 4, ["Urban", "Dug-in", "Clutter", "Random"]]]
+} else {
+	["TOOLBOX", ["IED Type", """Clutter"" transforms a random object of clutter into an IED"], [0, 1, 3, ["Urban", "Dug-in", "Random"]]]
+};
+
 [
 	"Spawn IED Clutter", 
 	[
@@ -41,7 +50,7 @@ private _onConfirm =
 		// ["CHECKBOX", "Electronics", [true]],
 		// ["CHECKBOX", "Wrecks", [false]],
 		["TOOLBOX", "IED Size", [0, 1, 3, ["Small", "Large", "Random"]]],
-		["TOOLBOX", ["IED Type", """Clutter"" transforms a random object of clutter into an IED"], [0, 1, 4, ["Urban", "Dug-in", "Clutter", "Random"]]],
+		_iedTypeToolbox,
 		["SLIDER", "IED Amount", [0, 10, 1, 0]]
 	],
 	_onConfirm,

--- a/CrowsZA/functions/fn_zeusRegister.sqf
+++ b/CrowsZA/functions/fn_zeusRegister.sqf
@@ -48,6 +48,7 @@ private _moduleList = [
     ["Fire Support",{_this call crowsZA_fnc_fireSupport}, "\x\zen\addons\modules\ui\target_ca.paa"],
     ["Resupply Player Loadouts",{_this call crowsZA_fnc_resupplyPlayerLoadouts}, "\CrowsZA\data\resupplyplayerloadout.paa"],
     ["Remove Radio/Bino",{_this call crowsZA_fnc_removeRadioBino}, "\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\call_ca.paa"],
+    ["Spawn IED Clutter",{_this call crowsZA_fnc_spawnIEDClutterZeus}, "\a3\ui_f\data\igui\cfg\simpletasks\types\destroy_ca.paa"],
     ["Strip Explosives",{_this call crowsZA_fnc_stripExplosivesZeus}, "\a3\ui_f\data\igui\cfg\simpletasks\types\destroy_ca.paa"],
     ["Set Teleport to Squadmember",{_this call crowsZA_fnc_setTeleportToSquadMemberZeus}, "\CrowsZA\data\tpToSquad.paa"]
 ];
@@ -59,8 +60,7 @@ if (crowsZA_common_aceModLoaded) then {
         ["Mass-Unconscious Toggle",{_this call crowsZA_fnc_massUnconscious}, "\z\ace\addons\zeus\UI\Icon_Module_Zeus_Unconscious_ca.paa"],
         ["Capture Player",{_this call crowsZA_fnc_capturePlayer}, "\z\ace\addons\captives\UI\captive_ca.paa"],
         ["Mass-Surrender Toggle",{_this call crowsZA_fnc_massSurrender}, "\z\ace\addons\captives\UI\Surrender_ca.paa"],
-        ["Set Supply Vehicle",{_this call crowsZA_fnc_setSupplyVehicle}, "\CrowsZA\data\rearmvehicle.paa"],
-        ["Spawn IED Clutter",{_this call crowsZA_fnc_spawnIEDClutterZeus}, "\a3\ui_f\data\igui\cfg\simpletasks\types\destroy_ca.paa"]
+        ["Set Supply Vehicle",{_this call crowsZA_fnc_setSupplyVehicle}, "\CrowsZA\data\rearmvehicle.paa"]
     ];
 };
 


### PR DESCRIPTION
Removed spawnIEDClutter's dependence on ACE; if ACE isn't loaded, basegame IEDs are used (with triggers to mimic ace's pressureplate behaviour)