### PR TITLE
Feature: module allowing toggling of AI pathing

### DIFF
--- a/CrowsZA/cfgFunctions.hpp
+++ b/CrowsZA/cfgFunctions.hpp
@@ -55,6 +55,8 @@ class CrowsZA_addon
 		class stripExplosives {};
 		class stripExplosivesZeus {};
 
+		class togglePathingZeus {};
+
 		class contextPasteLoadout {};
 		
 		class loadoutViewer {};

--- a/CrowsZA/functions/fn_togglePathingZeus.sqf
+++ b/CrowsZA/functions/fn_togglePathingZeus.sqf
@@ -1,0 +1,68 @@
+/*/////////////////////////////////////////////////
+Author: Landric
+			   
+File: fn_togglePathingZeus.sqf
+Parameters: pos, unit
+Return: none
+
+Allows zeus to toggle pathing for units, groups, or sides
+
+*///////////////////////////////////////////////
+
+params [["_pos",[0,0,0],[[]],3], ["_unit",objNull,[objNull]]];
+
+// ZEN Dialogue
+private _onConfirm =
+{
+	params ["_dialogResult","_in"];
+	_in params [["_pos",[0,0,0],[[]],3], ["_unit",objNull,[objNull]]];
+
+
+	private _units = if(isNull _unit) then {
+		_dialogResult params ["_side"];
+		units _side;
+	} else {
+		_dialogResult params ["_group"];
+		if(_group) then {
+			units (group _unit)
+		} else {
+			[_unit]
+		};
+	};
+
+	_dialogResult params ["_", "_action"];
+	{
+		if(isPlayer _x) then { continue };
+
+		switch(_action) do {
+			case 0: { _x disableAI "PATH"; };
+			case 1: { _x enableAI "PATH"; };
+			default {
+
+				if(_x checkAIFeature "PATH") then {
+					_x disableAI "PATH";
+				} else {
+					_x enableAI "PATH";
+				}
+			};
+		};	
+	} forEach _units;
+};
+
+private _controls = if(isNull _unit) then {
+	[["SIDES", "Side", east]]
+}
+else{
+	[["TOOLBOX:YESNO", ["Whole Group", "Affect pathing for the whole of this unit's group"], true]]
+};
+
+_controls pushBack ["TOOLBOX", ["Pathing", "AI's ability to 'path' (or move); note they will still turn, aim, and fire"], [2, 1, 3, ["Off", "On", "Toggle"]]];
+
+[
+	"Toggle Pathing",
+	_controls,
+	_onConfirm,
+	{},
+	_this
+] call zen_dialog_fnc_create;
+

--- a/CrowsZA/functions/fn_zeusRegister.sqf
+++ b/CrowsZA/functions/fn_zeusRegister.sqf
@@ -49,7 +49,8 @@ private _moduleList = [
     ["Resupply Player Loadouts",{_this call crowsZA_fnc_resupplyPlayerLoadouts}, "\CrowsZA\data\resupplyplayerloadout.paa"],
     ["Remove Radio/Bino",{_this call crowsZA_fnc_removeRadioBino}, "\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\call_ca.paa"],
     ["Strip Explosives",{_this call crowsZA_fnc_stripExplosivesZeus}, "\a3\ui_f\data\igui\cfg\simpletasks\types\destroy_ca.paa"],
-    ["Set Teleport to Squadmember",{_this call crowsZA_fnc_setTeleportToSquadMemberZeus}, "\CrowsZA\data\tpToSquad.paa"]
+    ["Set Teleport to Squadmember",{_this call crowsZA_fnc_setTeleportToSquadMemberZeus}, "\CrowsZA\data\tpToSquad.paa"],
+    ["Toggle AI Pathing",{_this call crowsZA_fnc_togglePathingZeus}, "\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa"]
 ];
 
 // check if ace is loaded


### PR DESCRIPTION
Added a module that allows toggling of AI pathing (resolves #78).

Can be applied to unit, group, or entire side.

Can force pathing off, on, or toggle the current state.

Note AI will still turn, aim, and fire at hostiles.