### PR TITLE
Context menu for toggling pathing

### DIFF
--- a/CrowsZA/cfgFunctions.hpp
+++ b/CrowsZA/cfgFunctions.hpp
@@ -70,6 +70,8 @@ class CrowsZA_addon
 		class resupplyPlayerLoadouts {};
 		class spawnSupplyDrop {};
 
+		class togglePathing {};
+
 		// draw building and helper functions
 		class getPosFromMouse {};
 		class drawBuildSelectPosition {};

--- a/CrowsZA/functions/fn_togglePathing.sqf
+++ b/CrowsZA/functions/fn_togglePathing.sqf
@@ -1,0 +1,38 @@
+/*/////////////////////////////////////////////////
+Author: Landric
+			   
+File: fn_togglePathing.sqf
+Parameters: 
+	units 	- [unit] the units to act on
+	action 	- int
+		0 - disable pathing
+		1 - enable pathing
+		2 - toggle pathing
+Return: success (bool)
+
+Toggle pathing for the passed units
+
+*///////////////////////////////////////////////
+
+params [["_units",[],[[objNull]],[]], ["_action", 0, [0]]];
+
+if(count _units == 0 || _action < 0 || _action > 2) exitWith { false };
+
+{
+	if(isPlayer _x) then { continue };
+
+	switch(_action) do {
+		case 0: { _x disableAI "PATH"; };
+		case 1: { _x enableAI "PATH"; };
+		default {
+			if(_x checkAIFeature "PATH") then {
+				_x disableAI "PATH";
+			} else {
+				_x enableAI "PATH";
+			}
+		};
+	};	
+} forEach _units;
+
+
+true

--- a/CrowsZA/functions/fn_zeusRegister.sqf
+++ b/CrowsZA/functions/fn_zeusRegister.sqf
@@ -90,6 +90,8 @@ if (isClass (configFile >> "CfgPatches" >> "task_force_radio")) then {
     };
 }] call CBA_fnc_addEventHandlerArgs;
 
+
+
 private _contextActionList = [
     // Action name, Display name, Icon and Icon colour, code, Condition to show, arguments, dynamic children, modifier functions
     [
@@ -125,6 +127,82 @@ private _contextActionList = [
     [
         ["jshk_heal","JSHK Heal","\z\ace\addons\medical_gui\ui\cross.paa", {_hoveredEntity call crowsZA_fnc_jshkHeal}, {[_hoveredEntity] call crowsZA_fnc_isAliveManUnit && crowsZA_common_aceModLoaded && crowsZA_common_jshkModLoaded && (_hoveredEntity getVariable ["ACE_isUnconscious", false]) == true}] call zen_context_menu_fnc_createAction,
         ["HealUnits"],
+        0
+    ],
+    [
+        ["toggle_pathing","Toggle Pathing","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {}, { isNull _hoveredEntity || {(typeName _hoveredEntity) isEqualTo "OBJECT" && {(group _hoveredEntity) isEqualTo grpNull}}}, [], {[
+            [["toggle_pathing_blufor","BLUFOR",["\A3\ui_f\data\map\markers\nato\b_unknown.paa", [0,0.3,0.6,1]], {[units west, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+                [["toggle_pathing_b_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units west, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_b_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units west, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_b_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units west, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
+            ]}] call zen_context_menu_fnc_createAction, [], 10],
+            [["toggle_pathing_opfor","OPFOR",["\A3\ui_f\data\map\markers\nato\o_unknown.paa", [0.5,0,0,1]], {[units east, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+                [["toggle_pathing_o_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units east, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_o_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units east, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_o_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units east, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
+            ]}] call zen_context_menu_fnc_createAction, [], 10],
+            [["toggle_pathing_indfor","INDFOR",["\A3\ui_f\data\map\markers\nato\n_unknown.paa", [0,0.5,0,1]], {[units independent, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+                [["toggle_pathing_i_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units independent, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_i_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units independent, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_i_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units independent, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
+            ]}] call zen_context_menu_fnc_createAction, [], 10],
+            [["toggle_pathing_civ","CIV",["\A3\ui_f\data\map\markers\nato\c_unknown.paa", [0.4,0,0.5,1]], {[units civilian, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+                [["toggle_pathing_c_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units civilian, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_c_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units civilian, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_c_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units civilian, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
+            ]}] call zen_context_menu_fnc_createAction, [], 10]
+        ]}] call zen_context_menu_fnc_createAction,
+        [],
+        0
+    ],
+    [
+        ["toggle_pathing","Toggle Pathing","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa",
+            {
+                if((typeName _hoveredEntity) isEqualTo "GROUP") then {
+                    [units _hoveredEntity, 2] call crowsZA_fnc_togglePathing;
+                } else {
+                    [[_hoveredEntity], 2] call crowsZA_fnc_togglePathing;
+                };
+            }, { !isNull _hoveredEntity && {(typeName _hoveredEntity) isEqualTo "GROUP" || {(typeName _hoveredEntity) isEqualTo "OBJECT" && {(group _hoveredEntity) isNotEqualTo grpNull}}} }, [], {[
+            [["toggle_pathing_unit","Unit","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { [[_hoveredEntity], 2] call crowsZA_fnc_togglePathing }, {((typeName _hoveredEntity) isEqualTo "OBJECT") && {(group _hoveredEntity) isNotEqualTo grpNull}}, [], {[
+                [["toggle_pathing_unit_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], { [[_hoveredEntity], 0] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_unit_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { [[_hoveredEntity], 1] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_unit_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], { [[_hoveredEntity], 2] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10]
+            ]}] call zen_context_menu_fnc_createAction, [], 10],
+
+            [["toggle_pathing_unit","Group","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { [units _hoveredEntity, 2] call crowsZA_fnc_togglePathing }, {true}, [], {[
+                [["toggle_pathing_group_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], { [units _hoveredEntity, 0] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_group_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { [units _hoveredEntity, 1] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_group_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], { [units _hoveredEntity, 2] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10]
+            ]}] call zen_context_menu_fnc_createAction, [], 10],
+
+            [["toggle_pathing_side","Side","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units (side _hoveredEntity), 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+                [["toggle_pathing_blufor","BLUFOR",["\A3\ui_f\data\map\markers\nato\b_unknown.paa", [0,0.3,0.6,1]], {[units west, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+                    [["toggle_pathing_b_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units west, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_b_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units west, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_b_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units west, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
+                ]}] call zen_context_menu_fnc_createAction, [], 10],
+                
+                [["toggle_pathing_opfor","OPFOR",["\A3\ui_f\data\map\markers\nato\o_unknown.paa", [0.5,0,0,1]], {[units east, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+                    [["toggle_pathing_o_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units east, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_o_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units east, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_o_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units east, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
+                ]}] call zen_context_menu_fnc_createAction, [], 10],
+
+                [["toggle_pathing_indfor","INDFOR",["\A3\ui_f\data\map\markers\nato\n_unknown.paa", [0,0.5,0,1]], {[units independent, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+                    [["toggle_pathing_i_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units independent, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_i_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units independent, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_i_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units independent, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
+                ]}] call zen_context_menu_fnc_createAction, [], 10],
+
+                [["toggle_pathing_civ","CIV",["\A3\ui_f\data\map\markers\nato\c_unknown.paa", [0.4,0,0.5,1]], {[units civilian, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+                    [["toggle_pathing_c_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units civilian, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_c_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units civilian, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_c_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units civilian, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
+                ]}] call zen_context_menu_fnc_createAction, [], 10]
+            ]}] call zen_context_menu_fnc_createAction, [], 10]
+        ]}] call zen_context_menu_fnc_createAction,
+        [],
         0
     ]
 ];

--- a/CrowsZA/functions/fn_zeusRegister.sqf
+++ b/CrowsZA/functions/fn_zeusRegister.sqf
@@ -130,53 +130,43 @@ private _contextActionList = [
         0
     ],
     [
-        ["toggle_pathing","Toggle Pathing","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {}, { isNull _hoveredEntity || {(typeName _hoveredEntity) isEqualTo "OBJECT" && {(group _hoveredEntity) isEqualTo grpNull}}}, [], {[
-            [["toggle_pathing_blufor","BLUFOR",["\A3\ui_f\data\map\markers\nato\b_unknown.paa", [0,0.3,0.6,1]], {[units west, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
-                [["toggle_pathing_b_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units west, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
-                [["toggle_pathing_b_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units west, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
-                [["toggle_pathing_b_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units west, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
+        ["toggle_pathing","Toggle Pathing","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {}, {true}, [], {[
+            [["toggle_pathing_radius","Radius","\CrowsZA\data\radiusheal.paa", {}, {true}, [], {[
+                [["toggle_pathing_radius_10","10m","\CrowsZA\data\radiusheal.paa", { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 10]; [_units, 2] call crowsZA_fnc_togglePathing }, {true}, [], {[
+                    [["toggle_pathing_unit_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 10]; [_units, 0] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_unit_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 10]; [_units, 1] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_unit_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 10]; [_units, 2] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10]
+                ]}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_radius_50","50m","\CrowsZA\data\radiusheal.paa", { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 50]; [_units, 2] call crowsZA_fnc_togglePathing }, {true}, [], {[
+                    [["toggle_pathing_unit_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 50]; [_units, 0] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_unit_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 50]; [_units, 1] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_unit_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 50]; [_units, 2] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10]
+                ]}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_radius_100","100m","\CrowsZA\data\radiusheal.paa", { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 100]; [_units, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+                    [["toggle_pathing_unit_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 100]; [_units, 0] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_unit_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 100]; [_units, 1] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_unit_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 100]; [_units, 2] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10]
+                ]}] call zen_context_menu_fnc_createAction, [], 10],
+                [["toggle_pathing_radius_200","200m","\CrowsZA\data\radiusheal.paa", { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 200]; [_units, 2] call crowsZA_fnc_togglePathing }, {true}, [], {[
+                    [["toggle_pathing_unit_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 200]; [_units, 0] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_unit_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 200]; [_units, 1] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
+                    [["toggle_pathing_unit_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], { private _units = (ASLToAGL _position) nearEntities [["Man", "LandVehicle"], 200]; [_units, 2] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10]
+                ]}] call zen_context_menu_fnc_createAction, [], 10]
             ]}] call zen_context_menu_fnc_createAction, [], 10],
-            [["toggle_pathing_opfor","OPFOR",["\A3\ui_f\data\map\markers\nato\o_unknown.paa", [0.5,0,0,1]], {[units east, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
-                [["toggle_pathing_o_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units east, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
-                [["toggle_pathing_o_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units east, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
-                [["toggle_pathing_o_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units east, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
-            ]}] call zen_context_menu_fnc_createAction, [], 10],
-            [["toggle_pathing_indfor","INDFOR",["\A3\ui_f\data\map\markers\nato\n_unknown.paa", [0,0.5,0,1]], {[units independent, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
-                [["toggle_pathing_i_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units independent, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
-                [["toggle_pathing_i_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units independent, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
-                [["toggle_pathing_i_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units independent, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
-            ]}] call zen_context_menu_fnc_createAction, [], 10],
-            [["toggle_pathing_civ","CIV",["\A3\ui_f\data\map\markers\nato\c_unknown.paa", [0.4,0,0.5,1]], {[units civilian, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
-                [["toggle_pathing_c_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units civilian, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
-                [["toggle_pathing_c_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units civilian, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
-                [["toggle_pathing_c_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], {[units civilian, 2] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10]
-            ]}] call zen_context_menu_fnc_createAction, [], 10]
-        ]}] call zen_context_menu_fnc_createAction,
-        [],
-        0
-    ],
-    [
-        ["toggle_pathing","Toggle Pathing","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa",
-            {
-                if((typeName _hoveredEntity) isEqualTo "GROUP") then {
-                    [units _hoveredEntity, 2] call crowsZA_fnc_togglePathing;
-                } else {
-                    [[_hoveredEntity], 2] call crowsZA_fnc_togglePathing;
-                };
-            }, { !isNull _hoveredEntity && {(typeName _hoveredEntity) isEqualTo "GROUP" || {(typeName _hoveredEntity) isEqualTo "OBJECT" && {(group _hoveredEntity) isNotEqualTo grpNull}}} }, [], {[
+
             [["toggle_pathing_unit","Unit","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { [[_hoveredEntity], 2] call crowsZA_fnc_togglePathing }, {((typeName _hoveredEntity) isEqualTo "OBJECT") && {(group _hoveredEntity) isNotEqualTo grpNull}}, [], {[
                 [["toggle_pathing_unit_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], { [[_hoveredEntity], 0] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
                 [["toggle_pathing_unit_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { [[_hoveredEntity], 1] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
                 [["toggle_pathing_unit_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], { [[_hoveredEntity], 2] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10]
             ]}] call zen_context_menu_fnc_createAction, [], 10],
 
-            [["toggle_pathing_unit","Group","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { [units _hoveredEntity, 2] call crowsZA_fnc_togglePathing }, {true}, [], {[
+            [["toggle_pathing_unit","Group","\A3\ui_f\data\map\markers\nato\o_unknown.paa", { [units _hoveredEntity, 2] call crowsZA_fnc_togglePathing }, {(typeName _hoveredEntity) isEqualTo "GROUP" || {((typeName _hoveredEntity) isEqualTo "OBJECT") && {(group _hoveredEntity) isNotEqualTo grpNull}}}, [], {[
                 [["toggle_pathing_group_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], { [units _hoveredEntity, 0] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
                 [["toggle_pathing_group_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", { [units _hoveredEntity, 1] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10],
                 [["toggle_pathing_group_toggle","Toggle",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0,0.3,0.6,1]], { [units _hoveredEntity, 2] call crowsZA_fnc_togglePathing }] call zen_context_menu_fnc_createAction, [], 10]
             ]}] call zen_context_menu_fnc_createAction, [], 10],
 
-            [["toggle_pathing_side","Side","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units (side _hoveredEntity), 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
+            [["toggle_pathing_side","Side","\A3\ui_f\data\map\markers\nato\b_unknown.paa", {}, {true}, [], {[
                 [["toggle_pathing_blufor","BLUFOR",["\A3\ui_f\data\map\markers\nato\b_unknown.paa", [0,0.3,0.6,1]], {[units west, 2] call crowsZA_fnc_togglePathing}, {true}, [], {[
                     [["toggle_pathing_b_off","Off",["\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", [0.5,0,0,1]], {[units west, 0] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],
                     [["toggle_pathing_b_on","On","\a3\ui_f\data\IGUI\Cfg\simpleTasks\types\walk_ca.paa", {[units west, 1] call crowsZA_fnc_togglePathing}] call zen_context_menu_fnc_createAction, [], 10],


### PR DESCRIPTION
Alternative approach to resolve #78 (instead of #80); adds a right-click context menu that allows zeus to toggle pathing for ai units, groups, or sides.