### PR TITLE
Add module to make units have a chance of surrendering when threatened

### DIFF
--- a/CrowsZA/cfgFunctions.hpp
+++ b/CrowsZA/cfgFunctions.hpp
@@ -55,6 +55,7 @@ class CrowsZA_addon
 		class stripExplosives {};
 		class stripExplosivesZeus {};
 
+		class surrender {};
 		class surrenderChance {};
 		class surrenderChanceZeus {};
 

--- a/CrowsZA/cfgFunctions.hpp
+++ b/CrowsZA/cfgFunctions.hpp
@@ -55,6 +55,9 @@ class CrowsZA_addon
 		class stripExplosives {};
 		class stripExplosivesZeus {};
 
+		class surrenderChance {};
+		class surrenderChanceZeus {};
+
 		class contextPasteLoadout {};
 		
 		class loadoutViewer {};

--- a/CrowsZA/functions/fn_addZeusTextDisplayEH.sqf
+++ b/CrowsZA/functions/fn_addZeusTextDisplayEH.sqf
@@ -92,3 +92,44 @@ crowsZA_unit_icon_drawEH = addMissionEventHandler ["Draw3D", {
 	} forEach _rcUnits;
 }];
 
+
+crowsZA_unit_surrender_drawEH = addMissionEventHandler ["Draw3D", {
+	// if zeus display is null, exit. Only drawing when zeus display is open
+	//if (isNull(findDisplay 312)) exitWith {};
+	if (isNull _x) exitWith {};
+	if (!crowsZA_zeus_surrender_helper) exitWith {};
+	if (uiNamespace getVariable ["RscDisplayCurator_screenshotMode", false]) exitWith {};
+
+	// cam position
+	private _zeusPos = positionCameraToWorld [0,0,0];
+
+	// SURRENDER ICON
+	{
+		_x params["_unit"];
+
+		// calculate distance from zeus camera to unit
+		private _dist = _zeusPos distance _unit;
+		private _scale = _dist * 0.01;
+		private _offset = 0.0;
+
+		// clamp max scale
+		if (_scale > 0.26) then {_scale = 0.26};
+
+		// // if not within 500m, we don't draw it as the text does not scale and disappear with distance
+		if (_dist > 500) then {continue;};
+
+		// //offset for longer distance
+		if (_dist > 60) then {
+			_offset = ((_dist - 60) * 0.03);
+		};
+
+		// draw icon on relative pos 
+		// offset: z: +2.15
+		private _pos = ASLToAGL getPosASLVisual _unit;
+		_pos = _pos vectorAdd [0, 0, 2.15 + _offset];
+
+		drawIcon3D ["\a3\ui_f\data\igui\cfg\holdactions\holdAction_secure_ca.paa", crowsZA_zeus_surrender_helper_color, _pos, 1 + _scale, 1 + _scale, 0];
+		// drawIcon3D ["\a3\ui_f_curator\data\logos\arma3_curator_eye_512_ca.paa", [1,1,1,1], [_pos#0, _pos#1, _pos#2 + 2.10 + (_dist * 2 ) + _offset], 0, 0, 0];
+	} forEach (missionNamespace getVariable["crowsZA_surrenderUnits", []]);
+}];
+

--- a/CrowsZA/functions/fn_addZeusTextDisplayEH.sqf
+++ b/CrowsZA/functions/fn_addZeusTextDisplayEH.sqf
@@ -49,6 +49,34 @@ crowsZA_unit_medical_drawEH = addMissionEventHandler ["Draw3D", {
 	} forEach crowsZA_medical_status_players;
 }];
 
+
+crowsza_fnc_drawIcon = {
+    params ["_zeusPos", "_unit", "_icon", "_color"];
+
+    // calculate distance from zeus camera to unit
+	private _dist = _zeusPos distance _unit;
+	private _scale = _dist * 0.01;
+	private _offset = 0.0;
+
+	// clamp max scale
+	if (_scale > 0.26) then {_scale = 0.26};
+
+	// // if not within 500m, we don't draw it as the text does not scale and disappear with distance
+	if (_dist > 500) then {continue;};
+
+	// //offset for longer distance
+	if (_dist > 60) then {
+		_offset = ((_dist - 60) * 0.03);
+	};
+
+	// draw icon on relative pos 
+	// offset: z: +2.15
+	private _pos = ASLToAGL getPosASLVisual _unit;
+	_pos = _pos vectorAdd [0, 0, 2.15 + _offset];
+
+	drawIcon3D [_icon, _color, _pos, 1 + _scale, 1 + _scale, 0];
+};
+
 crowsZA_unit_icon_drawEH = addMissionEventHandler ["Draw3D", {
 	// if zeus display is null, exit. Only drawing when zeus display is open
 	//if (isNull(findDisplay 312)) exitWith {};
@@ -65,30 +93,7 @@ crowsZA_unit_icon_drawEH = addMissionEventHandler ["Draw3D", {
 	// RC ICON
 	{
 		_x params["_unit"];
-
-		// calculate distance from zeus camera to unit
-		private _dist = _zeusPos distance _unit;
-		private _scale = _dist * 0.01;
-		private _offset = 0.0;
-
-		// clamp max scale
-		if (_scale > 0.26) then {_scale = 0.26};
-
-		// // if not within 500m, we don't draw it as the text does not scale and disappear with distance
-		if (_dist > 500) then {continue;};
-
-		// //offset for longer distance
-		if (_dist > 60) then {
-			_offset = ((_dist - 60) * 0.03);
-		};
-
-		// draw icon on relative pos 
-		// offset: z: +2.15
-		private _pos = ASLToAGL getPosASLVisual _unit;
-		_pos = _pos vectorAdd [0, 0, 2.15 + _offset];
-
-		drawIcon3D ["\a3\ui_f_curator\data\logos\arma3_curator_eye_512_ca.paa", crowsZA_zeus_rc_helper_color, _pos, 1 + _scale, 1 + _scale, 0];
-		// drawIcon3D ["\a3\ui_f_curator\data\logos\arma3_curator_eye_512_ca.paa", [1,1,1,1], [_pos#0, _pos#1, _pos#2 + 2.10 + (_dist * 2 ) + _offset], 0, 0, 0];
+		[_zeusPos, _unit, "\a3\ui_f_curator\data\logos\arma3_curator_eye_512_ca.paa", crowsZA_zeus_rc_helper_color] call crowsza_fnc_drawIcon;
 	} forEach _rcUnits;
 }];
 
@@ -106,30 +111,7 @@ crowsZA_unit_surrender_drawEH = addMissionEventHandler ["Draw3D", {
 	// SURRENDER ICON
 	{
 		_x params["_unit"];
-
-		// calculate distance from zeus camera to unit
-		private _dist = _zeusPos distance _unit;
-		private _scale = _dist * 0.01;
-		private _offset = 0.0;
-
-		// clamp max scale
-		if (_scale > 0.26) then {_scale = 0.26};
-
-		// // if not within 500m, we don't draw it as the text does not scale and disappear with distance
-		if (_dist > 500) then {continue;};
-
-		// //offset for longer distance
-		if (_dist > 60) then {
-			_offset = ((_dist - 60) * 0.03);
-		};
-
-		// draw icon on relative pos 
-		// offset: z: +2.15
-		private _pos = ASLToAGL getPosASLVisual _unit;
-		_pos = _pos vectorAdd [0, 0, 2.15 + _offset];
-
-		drawIcon3D ["\a3\ui_f\data\igui\cfg\holdactions\holdAction_secure_ca.paa", crowsZA_zeus_surrender_helper_color, _pos, 1 + _scale, 1 + _scale, 0];
-		// drawIcon3D ["\a3\ui_f_curator\data\logos\arma3_curator_eye_512_ca.paa", [1,1,1,1], [_pos#0, _pos#1, _pos#2 + 2.10 + (_dist * 2 ) + _offset], 0, 0, 0];
+		[_zeusPos, _unit, "\a3\ui_f\data\igui\cfg\holdactions\holdAction_secure_ca.paa", crowsZA_zeus_surrender_helper_color] call crowsza_fnc_drawIcon;
 	} forEach (missionNamespace getVariable["crowsZA_surrenderUnits", []]);
 }];
 

--- a/CrowsZA/functions/fn_registerSettingsCBA.sqf
+++ b/CrowsZA/functions/fn_registerSettingsCBA.sqf
@@ -71,6 +71,26 @@ if (!hasInterface) exitWith {};
     [1,1,1,1]
 ] call CBA_fnc_addSetting;
 
+
+// ZEUS SURRENDER HELPER
+[
+	"crowsZA_zeus_surrender_helper",
+    "CHECKBOX",
+    ["Show Surrender Icon","Shows an icon over units with a chance to surrender"],
+    ["Crows Zeus Additions","Surrender Chance"],
+    true
+] call CBA_fnc_addSetting;
+
+// ZEUS SURRENDER HELPER - COLOR
+[
+	"crowsZA_zeus_surrender_helper_color",
+    "COLOR",
+    ["Icon Colour","What colour the icon is shown with"],
+    ["Crows Zeus Additions","Surrender Chance"],
+    [1,1,1,1]
+] call CBA_fnc_addSetting;
+
+
 // custom CBA setting to disable pingbox
 [
 	"crowsZA_CBA_Setting_pingbox_enabled",

--- a/CrowsZA/functions/fn_surrender.sqf
+++ b/CrowsZA/functions/fn_surrender.sqf
@@ -13,7 +13,7 @@ https://steamcommunity.com/sharedfiles/filedetails/?id=2942202773
 *///////////////////////////////////////////////
 
 if (crowsZA_common_aceModLoaded) then {
-	["ace_captives_setSurrendered",[_unit,true]] call CBA_fnc_globalEvent;
+	["ace_captives_setSurrendered",[_unit,true], _unit] call CBA_fnc_targetEvent;
 } else {
 	_unit action ["surrender", _unit];
 };

--- a/CrowsZA/functions/fn_surrender.sqf
+++ b/CrowsZA/functions/fn_surrender.sqf
@@ -1,0 +1,29 @@
+/*/////////////////////////////////////////////////
+Author: Landric
+			   
+File: fn_surrender.sqf
+Parameters:
+	unit - (unit) unit to surrender
+
+Return: nothing
+
+This code inspired by CQB Interactions By Flex7103
+https://steamcommunity.com/sharedfiles/filedetails/?id=2942202773
+
+*///////////////////////////////////////////////
+
+if (crowsZA_common_aceModLoaded) then {
+	["ace_captives_setSurrendered",[_unit,true]] call CBA_fnc_globalEvent;
+} else {
+	_unit action ["surrender", _unit];
+};
+
+_weapon = currentWeapon _unit;
+_unit removeWeapon (currentWeapon _unit); 
+_weaponHolder = "WeaponHolderSimulated" createVehicle [0,0,0]; 
+_weaponHolder addWeaponCargoGlobal [_weapon,1]; 
+_weaponHolder setPos (_unit modelToWorld [0,.2,1.2]); 
+_weaponHolder disableCollisionWith _unit; 
+_dir = random(360); 
+_speed = 1; 
+_weaponHolder setVelocity [_speed * sin(_dir), _speed * cos(_dir),4];

--- a/CrowsZA/functions/fn_surrender.sqf
+++ b/CrowsZA/functions/fn_surrender.sqf
@@ -5,12 +5,16 @@ File: fn_surrender.sqf
 Parameters:
 	unit - (unit) unit to surrender
 
-Return: nothing
+Return: bool - success
 
 This code inspired by CQB Interactions By Flex7103
 https://steamcommunity.com/sharedfiles/filedetails/?id=2942202773
 
 *///////////////////////////////////////////////
+
+params [["_unit", objNull, [objNull]]];
+
+if(isNull _unit || {!alive _unit}) exitWith { false };
 
 if (crowsZA_common_aceModLoaded) then {
 	["ace_captives_setSurrendered",[_unit,true], _unit] call CBA_fnc_targetEvent;
@@ -27,3 +31,5 @@ _weaponHolder disableCollisionWith _unit;
 _dir = random(360); 
 _speed = 1; 
 _weaponHolder setVelocity [_speed * sin(_dir), _speed * cos(_dir),4];
+
+true

--- a/CrowsZA/functions/fn_surrender.sqf
+++ b/CrowsZA/functions/fn_surrender.sqf
@@ -23,6 +23,7 @@ if (crowsZA_common_aceModLoaded) then {
 };
 
 _weapon = currentWeapon _unit;
+if(_weapon isEqualTo "") exitWith { false };
 _unit removeWeapon (currentWeapon _unit); 
 _weaponHolder = "WeaponHolderSimulated" createVehicle [0,0,0]; 
 _weaponHolder addWeaponCargoGlobal [_weapon,1]; 

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -1,0 +1,137 @@
+/*/////////////////////////////////////////////////
+Author: Landric
+			   
+File: fn_surrenderChance.sqf
+Parameters:
+	unit					- (unit)
+	confrontationRadius		- (float) radius within which pointing a weapon at the unit will trigger a response
+	surrenderChance			- (float) min: 0 max: 1
+	holdFire				- (bool) will unit hold fire until confronted
+	hesitation				- (float) maximum time unit will stall before acting once confronted
+
+Return: bool        		- True if method ran successfully, false if aborted (i.e. bad params were passed)
+
+// This code inspired by CQB Interactions By Flex7103
+// https://steamcommunity.com/sharedfiles/filedetails/?id=2942202773
+
+*///////////////////////////////////////////////
+params [
+	["_unit", objNull, [objNull]],
+	["_confrontationRadius", 15, [15]],
+	["_surrenderChance", 0.33, [0.33]],
+	["_holdFire", true, [true]],
+	["_hesitation", 0, [0]]
+];
+
+
+if(isNull _unit) exitWith { false };
+
+
+// TODO: Add check if unit has already had this module applied/is already surrendered/etc
+
+
+if(_holdFire) then {
+	_unit setUnitCombatMode "BLUE";
+	_unit setCombatBehaviour "CARELESS";
+};
+
+
+private _trigger = createTrigger ["EmptyDetector", getPos _unit, false];
+_trigger setTriggerArea [_confrontationRadius, _confrontationRadius, 0, false];
+_trigger setTriggerActivation ["ANYPLAYER", "PRESENT", true];
+
+_trigger setVariable ["_unit", _unit];
+_unit setVariable ["_trigger", _trigger];
+_unit setVariable ["_hesitation", _hesitation];
+_unit setVariable ["_surrenderChance", _surrenderChance];
+
+_trigger attachTo [_unit];
+
+
+// TODO: Ensure that the player pointing a weapon is considered HOSTILE to the units side
+
+private _condition = "
+if(!this) exitWith { false };
+private _unit = thisTrigger getVariable ""_unit"";
+{
+	[_unit, {
+		missionNamespace setVariable [
+			""LND_unit_callback"",
+			(toUpperANSI cameraView == ""GUNNER"") && (cursorObject == _this),
+			remoteExecutedOwner
+		];
+	}] remoteExecCall [""call"", _x];
+
+	if((missionNamespace getVariable ""LND_unit_callback"")) exitWith {true};
+} forEach thisList;
+(missionNamespace getVariable ""LND_unit_callback"")
+";
+
+
+private _activation = "
+private _unit = thisTrigger getVariable ""_unit"";
+private _surrenderChance = _unit getVariable ""_surrenderChance"";
+private _hesitation = _unit getVariable ""_hesitation"";
+
+[_unit, _surrenderChance, _hesitation, thisTrigger] spawn {
+
+	params [""_unit"", ""_surrenderChance"", ""_hesitation"", ""_trigger""];
+
+	sleep ([random (0.5 + _hesitation), 0.5, _hesitation] call BIS_fnc_clamp);
+
+
+	if(random 1 < _surrenderChance) then {
+
+		if (crowsZA_common_aceModLoaded) then {
+			[""ace_captives_setSurrendered"",[_unit,true]] call CBA_fnc_globalEvent;
+		} else {
+			_unit action [""surrender"", _unit];
+		};
+		
+		_weapon = currentWeapon _unit;
+		_unit removeWeapon (currentWeapon _unit); 
+		_weaponHolder = ""WeaponHolderSimulated"" createVehicle [0,0,0]; 
+		_weaponHolder addWeaponCargoGlobal [_weapon,1]; 
+		_weaponHolder setPos (_unit modelToWorld [0,.2,1.2]); 
+		_weaponHolder disableCollisionWith _unit; 
+		_dir = random(360); 
+		_speed = 1; 
+		_weaponHolder setVelocity [_speed * sin(_dir), _speed * cos(_dir),4];
+	} else {
+		_unit setUnitCombatMode ""RED"";
+		_unit setCombatBehaviour ""COMBAT"";
+	};
+
+	deletevehicle _trigger;
+
+};
+";
+
+_trigger setTriggerStatements [
+	_condition,
+	_activation,
+	""
+];
+
+_unit addEventHandler ["Deleted", {
+	params ["_entity"];
+	deleteVehicle (_entity getVariable "_trigger");
+}];
+
+_unit addEventHandler ["Killed", {
+	params ["_unit", "_killer", "_instigator", "_useEffects"];
+	deleteVehicle (_unit getVariable "_trigger");
+}];
+
+
+_unit addEventHandler ["HandleDamage", {
+	params ["_unit", "_selection", "_damage", "_source", "_projectile", "_hitIndex", "_instigator", "_hitPoint", "_directHit"];
+
+	_unit setUnitCombatMode "RED";
+	_unit setCombatBehaviour "COMBAT";
+	deletevehicle (_unit getVariable "_trigger");
+
+}];
+
+
+true

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -41,7 +41,7 @@ if(_holdFire) then {
 
 private _trigger = createTrigger ["EmptyDetector", getPos _unit, false];
 _trigger setTriggerArea [_confrontationRadius, _confrontationRadius, 0, false];
-_trigger setTriggerActivation ["ANYPLAYER", "PRESENT", true];
+_trigger setTriggerActivation ["ANYPLAYER", "PRESENT", false];
 
 _trigger setVariable ["_unit", _unit];
 _unit setVariable ["_trigger", _trigger];

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -27,6 +27,8 @@ if(isNull _unit) exitWith { false };
 
 if(_unit getVariable ["crowsza_surrender_chance_applied", false]) exitWith { ["Surrender chance already applied to this unit"] call crowsZA_fnc_showHint; false };
 
+
+// TODO: add to CZA draw handler so zeuses can see which units have had this applied (similar to Remote Control)
 _unit setVariable ["crowsza_surrender_chance_applied", true, true];
 
 

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -66,9 +66,9 @@ private _unit = thisTrigger getVariable ""_unit"";
 		];
 	}] remoteExecCall [""call"", _x];
 
-	if((missionNamespace getVariable (""crowsza_surrender_chance_"" + str (_this call BIS_fnc_netId)))) exitWith {true};
+	if((missionNamespace getVariable (""crowsza_surrender_chance_"" + str (_unit call BIS_fnc_netId)))) exitWith {true};
 } forEach thisList;
-(missionNamespace getVariable (""crowsza_surrender_chance_"" + str (_this call BIS_fnc_netId)))
+(missionNamespace getVariable (""crowsza_surrender_chance_"" + str (_unit call BIS_fnc_netId)))
 ";
 
 

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -11,8 +11,8 @@ Parameters:
 
 Return: bool        		- True if method ran successfully, false if aborted (e.g. bad params were passed)
 
-// This code inspired by CQB Interactions By Flex7103
-// https://steamcommunity.com/sharedfiles/filedetails/?id=2942202773
+This code inspired by CQB Interactions By Flex7103
+https://steamcommunity.com/sharedfiles/filedetails/?id=2942202773
 
 *///////////////////////////////////////////////
 params [
@@ -89,22 +89,7 @@ deletevehicle thisTrigger;
 
 
 	if(random 1 < _surrenderChance) then {
-
-		if (crowsZA_common_aceModLoaded) then {
-			[""ace_captives_setSurrendered"",[_unit,true]] call CBA_fnc_globalEvent;
-		} else {
-			_unit action [""surrender"", _unit];
-		};
-		
-		_weapon = currentWeapon _unit;
-		_unit removeWeapon (currentWeapon _unit); 
-		_weaponHolder = ""WeaponHolderSimulated"" createVehicle [0,0,0]; 
-		_weaponHolder addWeaponCargoGlobal [_weapon,1]; 
-		_weaponHolder setPos (_unit modelToWorld [0,.2,1.2]); 
-		_weaponHolder disableCollisionWith _unit; 
-		_dir = random(360); 
-		_speed = 1; 
-		_weaponHolder setVelocity [_speed * sin(_dir), _speed * cos(_dir),4];
+		[_unit] call crowsZA_fnc_surrender;
 	} else {
 		_unit setUnitCombatMode ""RED"";
 		_unit setCombatBehaviour ""COMBAT"";
@@ -141,21 +126,7 @@ private _eh = _unit addEventHandler ["HandleDamage", {
 				_unit setUnitCombatMode "RED";
 				_unit setCombatBehaviour "COMBAT";
 			} else {
-				if (crowsZA_common_aceModLoaded) then {
-					["ace_captives_setSurrendered",[_unit,true]] call CBA_fnc_globalEvent;
-				} else {
-					_unit action ["surrender", _unit];
-				};
-
-				_weapon = currentWeapon _unit;
-				_unit removeWeapon (currentWeapon _unit); 
-				_weaponHolder = "WeaponHolderSimulated" createVehicle [0,0,0]; 
-				_weaponHolder addWeaponCargoGlobal [_weapon,1]; 
-				_weaponHolder setPos (_unit modelToWorld [0,.2,1.2]); 
-				_weaponHolder disableCollisionWith _unit; 
-				_dir = random(360); 
-				_speed = 1; 
-				_weaponHolder setVelocity [_speed * sin(_dir), _speed * cos(_dir),4];
+				[_unit] call crowsZA_fnc_surrender;
 			};
 
 			deletevehicle (_unit getVariable "_trigger");

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -74,9 +74,11 @@ private _unit = thisTrigger getVariable ""_unit"";
 private _surrenderChance = _unit getVariable ""_surrenderChance"";
 private _hesitation = _unit getVariable ""_hesitation"";
 
+deletevehicle thisTrigger;
+
 [_unit, _surrenderChance, _hesitation, thisTrigger] spawn {
 
-	params [""_unit"", ""_surrenderChance"", ""_hesitation"", ""_trigger""];
+	params [""_unit"", ""_surrenderChance"", ""_hesitation""];
 
 	sleep ([random (0.5 + _hesitation), 0.5, _hesitation] call BIS_fnc_clamp);
 
@@ -102,9 +104,6 @@ private _hesitation = _unit getVariable ""_hesitation"";
 		_unit setUnitCombatMode ""RED"";
 		_unit setCombatBehaviour ""COMBAT"";
 	};
-
-	deletevehicle _trigger;
-
 };
 ";
 

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -23,11 +23,12 @@ params [
 	["_hesitation", 0, [0]]
 ];
 
-
 if(isNull _unit) exitWith { false };
 
 
-// TODO: Add check if unit has already had this module applied/is already surrendered/etc
+if(_unit getVariable ["crowsza_surrender_chance_applied", false]) exitWith { ["Surrender chance already applied to this unit"] call crowsZA_fnc_showHint; false }
+
+_unit setVariable ["crowsza_surrender_chance_applied", true, true];
 
 
 if(_holdFire) then {

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -66,9 +66,9 @@ private _unit = thisTrigger getVariable ""_unit"";
 		];
 	}] remoteExecCall [""call"", _x];
 
-	if((missionNamespace getVariable (""crowsza_surrender_chance_"" + str _unit))) exitWith {true};
+	if((missionNamespace getVariable (""crowsza_surrender_chance_"" + str (_this call BIS_fnc_netId)))) exitWith {true};
 } forEach thisList;
-(missionNamespace getVariable (""crowsza_surrender_chance_"" + str _unit))
+(missionNamespace getVariable (""crowsza_surrender_chance_"" + str (_this call BIS_fnc_netId)))
 ";
 
 

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -27,9 +27,15 @@ if(isNull _unit) exitWith { false };
 
 if(_unit getVariable ["crowsza_surrender_chance_applied", false]) exitWith { ["Surrender chance already applied to this unit"] call crowsZA_fnc_showHint; false };
 
-
-// TODO: add to CZA draw handler so zeuses can see which units have had this applied (similar to Remote Control)
+// Tag this unit so that this function isn't applied twice
 _unit setVariable ["crowsza_surrender_chance_applied", true, true];
+
+
+// Add this unit to the list of units with this module applied, for drawing icons
+private _surrenderUnits = missionNamespace getVariable["crowsZA_surrenderUnits", []];
+_surrenderUnits pushBack _unit;
+_surrenderUnits = _surrenderUnits arrayIntersect _surrenderUnits;
+missionNamespace setVariable["crowsZA_surrenderUnits", _surrenderUnits, true];
 
 
 if(_holdFire) then {
@@ -87,7 +93,6 @@ deletevehicle thisTrigger;
 
 	sleep ([random (0.5 + _hesitation), 0.5, _hesitation] call BIS_fnc_clamp);
 
-
 	if(random 1 < _surrenderChance) then {
 		[_unit] call crowsZA_fnc_surrender;
 	} else {
@@ -143,12 +148,24 @@ _unit setVariable ["crowsza_surrChance_ehDamaged", _eh];
 _unit addEventHandler ["Deleted", {
 	params ["_entity"];
 	deleteVehicle (_entity getVariable "_trigger");
+
+	// Remove unit from list of units with the module applied
+	private _surrenderUnits = missionNamespace getVariable["crowsZA_surrenderUnits", []];
+	_surrenderUnits = _surrenderUnits - [_entity];
+	_surrenderUnits = _surrenderUnits arrayIntersect _surrenderUnits;
+	missionNamespace setVariable["crowsZA_surrenderUnits", _surrenderUnits, true];
 }];
 
 _unit addEventHandler ["Killed", {
 	params ["_unit", "_killer", "_instigator", "_useEffects"];
 	deleteVehicle (_unit getVariable "_trigger");
 	_unit removeEventHandler ["HandleDamage", _unit getVariable "crowsza_surrChance_ehDamaged"];
+	
+	// Remove unit from list of units with the module applied
+	private _surrenderUnits = missionNamespace getVariable["crowsZA_surrenderUnits", []];
+	_surrenderUnits = _surrenderUnits - [_unit];
+	_surrenderUnits = _surrenderUnits arrayIntersect _surrenderUnits;
+	missionNamespace setVariable["crowsZA_surrenderUnits", _surrenderUnits, true];
 }];
 
 

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -48,7 +48,8 @@ _unit setVariable ["_surrenderChance", _surrenderChance];
 _trigger attachTo [_unit];
 
 
-// TODO: Ensure that the player pointing a weapon is considered HOSTILE to the units side
+// TODO: Optionally ensure that the player pointing a weapon is considered HOSTILE to the units side
+// (don't mandate - could be useful to encourage friendly units, e.g. CIVs, to surrender too)
 
 private _condition = "
 if(!this) exitWith { false };

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -60,7 +60,7 @@ private _unit = thisTrigger getVariable ""_unit"";
 {
 	[_unit, {
 		missionNamespace setVariable [
-			""crowsza_surrender_chance_"" + str _this,
+			""crowsza_surrender_chance_"" + str (_this call BIS_fnc_netId),
 			(toUpperANSI cameraView == ""GUNNER"") && (cursorObject == _this),
 			remoteExecutedOwner
 		];

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -9,7 +9,7 @@ Parameters:
 	holdFire				- (bool) will unit hold fire until confronted
 	hesitation				- (float) maximum time unit will stall before acting once confronted
 
-Return: bool        		- True if method ran successfully, false if aborted (i.e. bad params were passed)
+Return: bool        		- True if method ran successfully, false if aborted (e.g. bad params were passed)
 
 // This code inspired by CQB Interactions By Flex7103
 // https://steamcommunity.com/sharedfiles/filedetails/?id=2942202773
@@ -25,8 +25,7 @@ params [
 
 if(isNull _unit) exitWith { false };
 
-
-if(_unit getVariable ["crowsza_surrender_chance_applied", false]) exitWith { ["Surrender chance already applied to this unit"] call crowsZA_fnc_showHint; false }
+if(_unit getVariable ["crowsza_surrender_chance_applied", false]) exitWith { ["Surrender chance already applied to this unit"] call crowsZA_fnc_showHint; false };
 
 _unit setVariable ["crowsza_surrender_chance_applied", true, true];
 
@@ -58,15 +57,15 @@ private _unit = thisTrigger getVariable ""_unit"";
 {
 	[_unit, {
 		missionNamespace setVariable [
-			""LND_unit_callback"",
+			""crowsza_surrender_chance_"" + str _this,
 			(toUpperANSI cameraView == ""GUNNER"") && (cursorObject == _this),
 			remoteExecutedOwner
 		];
 	}] remoteExecCall [""call"", _x];
 
-	if((missionNamespace getVariable ""LND_unit_callback"")) exitWith {true};
+	if((missionNamespace getVariable (""crowsza_surrender_chance_"" + str _unit))) exitWith {true};
 } forEach thisList;
-(missionNamespace getVariable ""LND_unit_callback"")
+(missionNamespace getVariable (""crowsza_surrender_chance_"" + str _unit))
 ";
 
 
@@ -75,6 +74,8 @@ private _unit = thisTrigger getVariable ""_unit"";
 private _surrenderChance = _unit getVariable ""_surrenderChance"";
 private _hesitation = _unit getVariable ""_hesitation"";
 
+missionNamespace setVariable [(""crowsza_surrender_chance_"" + str _unit), nil];
+_unit setVariable [""crowsza_surrender_chance_applied"", nil, true];
 deletevehicle thisTrigger;
 
 [_unit, _surrenderChance, _hesitation, thisTrigger] spawn {

--- a/CrowsZA/functions/fn_surrenderChance.sqf
+++ b/CrowsZA/functions/fn_surrenderChance.sqf
@@ -33,8 +33,9 @@ _unit setVariable ["crowsza_surrender_chance_applied", true, true];
 
 
 if(_holdFire) then {
-	_unit setUnitCombatMode "BLUE";
-	_unit setCombatBehaviour "CARELESS";
+	// Set the combat mode of the whole group, to avoid the entire group
+	// opening fire when one "snaps"
+	_unit setCombatMode "BLUE";
 };
 
 

--- a/CrowsZA/functions/fn_surrenderChanceZeus.sqf
+++ b/CrowsZA/functions/fn_surrenderChanceZeus.sqf
@@ -15,7 +15,7 @@ private _onConfirm =
 
 	private _units = if(isNull _unit) then {
 		private _u = [];
-		{ _u insert [-1, units _x, true]; } forEach ((ASLToAGL _pos) nearEntities [["Man"], (_dialogResult deleteAt 0)]);
+		{ _u insert [-1, units _x, true]; } forEach ((ASLToAGL _pos) nearEntities [["CAManBase"], (_dialogResult deleteAt 0)]);
 		_u
 	} else {
 		units group _unit

--- a/CrowsZA/functions/fn_surrenderChanceZeus.sqf
+++ b/CrowsZA/functions/fn_surrenderChanceZeus.sqf
@@ -16,7 +16,7 @@ private _onConfirm =
 	private _units = if(isNull _unit) then {
 		units (_dialogResult deleteAt 0)
 	} else {
-		[[_unit], units group _unit] select (_dialogResult deleteAt 0)
+		units group _unit
 	};
 	_dialogResult params [
 		["_confrontationRadius", 15, [15]],
@@ -33,7 +33,6 @@ private _onConfirm =
 
 private _controls = [
 		["SIDES", "Side", east],
-		["CHECKBOX", ["Apply to group", "Apply to the unit's whole group"], [true]],
 		["SLIDER", ["Confrontation Radius", "Radius within which pointing a weapon at the unit will trigger a response"], [5, 50, 15, 0]],
 		["SLIDER:PERCENT", "Surrender Chance", [0, 1, 0.33, 0]],
 		["CHECKBOX", ["Hold Fire", "Units will hold fire until confronted"], [true]],
@@ -42,8 +41,6 @@ private _controls = [
 
 if(!(isNull _unit)) then {
 	_controls deleteAt 0;
-} else {
-	_controls deleteAt 1;
 };
 
 

--- a/CrowsZA/functions/fn_surrenderChanceZeus.sqf
+++ b/CrowsZA/functions/fn_surrenderChanceZeus.sqf
@@ -12,45 +12,23 @@ private _onConfirm =
 {
 	params ["_dialogResult","_in"];
 	_in params [["_pos",[0,0,0],[[]],3], "_unit"];
-	private "_units";
 
-	if(isNull _unit) then {
-		_dialogResult params [
-			["_side", east, [east]],
-			["_confrontationRadius", 15, [15]],
-			["_surrenderChance", 0.33, [0.33]],
-			["_holdFire", true, [true]],
-			["_hesitation", 0, [0]]
-		];
-		_units = units _side;
-		[_units, _confrontationRadius, _surrenderChance, _holdFire, _hesitation] spawn {
-			params["_units", "_confrontationRadius", "_surrenderChance", "_holdFire", "_hesitation"];
-			{
-				if(!(isPlayer _x)) then {
-					[_x, _confrontationRadius, _surrenderChance, _holdFire, _hesitation] call crowsZA_fnc_surrenderChance;
-					sleep 0.01;
-				};
-			} foreach _units;
-		};
+	private _units = if(isNull _unit) then {
+		units (_dialogResult deleteAt 0)
 	} else {
-		_dialogResult params [
-			["_group", true, [true]],
-			["_confrontationRadius", 15, [15]],
-			["_surrenderChance", 0.33, [0.33]],
-			["_holdFire", true, [true]],
-			["_hesitation", 0, [0]]
-		];
-		_units = [[_unit], units group _unit] select _group;
-		[_units, _confrontationRadius, _surrenderChance, _holdFire, _hesitation] spawn {
-			params["_units", "_confrontationRadius", "_surrenderChance", "_holdFire", "_hesitation"];
-			{
-				if(!(isPlayer _x)) then {
-					[_x, _confrontationRadius, _surrenderChance, _holdFire, _hesitation] call crowsZA_fnc_surrenderChance;
-					sleep 0.01;
-				};
-			} foreach _units;
-		};
+		[[_unit], units group _unit] select (_dialogResult deleteAt 0)
 	};
+	_dialogResult params [
+		["_confrontationRadius", 15, [15]],
+		["_surrenderChance", 0.33, [0.33]],
+		["_holdFire", true, [true]],
+		["_hesitation", 0, [0]]
+	];
+	{
+		if(!(isPlayer _x)) then {
+			 [crowsZA_fnc_surrenderChance, [_x, _confrontationRadius, _surrenderChance, _holdFire, _hesitation], 0.01] call CBA_fnc_waitAndExecute;
+		};
+	} foreach _units;
 };
 
 private _controls = [

--- a/CrowsZA/functions/fn_surrenderChanceZeus.sqf
+++ b/CrowsZA/functions/fn_surrenderChanceZeus.sqf
@@ -1,0 +1,81 @@
+/*/////////////////////////////////////////////////
+Author: Landric
+			   
+File: fn_surrenderChanceZeus.sqf
+Parameters: pos, unit
+Return: none
+
+*///////////////////////////////////////////////
+params [["_pos",[0,0,0],[[]],3], ["_unit",objNull,[objNull]]];
+
+private _onConfirm =
+{
+	params ["_dialogResult","_in"];
+	_in params [["_pos",[0,0,0],[[]],3], "_unit"];
+	private "_units";
+
+	if(isNull _unit) then {
+		_dialogResult params [
+			["_side", east, [east]],
+			["_confrontationRadius", 15, [15]],
+			["_surrenderChance", 0.33, [0.33]],
+			["_holdFire", true, [true]],
+			["_hesitation", 0, [0]]
+		];
+		_units = units _side;
+		[_units, _confrontationRadius, _surrenderChance, _holdFire, _hesitation] spawn {
+			params["_units", "_confrontationRadius", "_surrenderChance", "_holdFire", "_hesitation"];
+			{
+				if(!(isPlayer _x)) then {
+					[_x, _confrontationRadius, _surrenderChance, _holdFire, _hesitation] call crowsZA_fnc_surrenderChance;
+					sleep 0.01;
+				};
+			} foreach _units;
+		};
+	} else {
+		_dialogResult params [
+			["_group", true, [true]],
+			["_confrontationRadius", 15, [15]],
+			["_surrenderChance", 0.33, [0.33]],
+			["_holdFire", true, [true]],
+			["_hesitation", 0, [0]]
+		];
+		_units = [[_unit], units group _unit] select _group;
+		[_units, _confrontationRadius, _surrenderChance, _holdFire, _hesitation] spawn {
+			params["_units", "_confrontationRadius", "_surrenderChance", "_holdFire", "_hesitation"];
+			{
+				if(!(isPlayer _x)) then {
+					[_x, _confrontationRadius, _surrenderChance, _holdFire, _hesitation] call crowsZA_fnc_surrenderChance;
+					sleep 0.01;
+				};
+			} foreach _units;
+		};
+	};
+};
+
+private _controls = [
+		["SIDES", "Side", east],
+		["CHECKBOX", ["Apply to group", "Apply to the unit's whole group"], [true]],
+		["SLIDER", ["Confrontation Radius", "Radius within which pointing a weapon at the unit will trigger a response"], [5, 50, 15, 0]],
+		["SLIDER:PERCENT", "Surrender Chance", [0, 1, 0.33, 0]],
+		["CHECKBOX", ["Hold Fire", "Units will hold fire until confronted"], [true]],
+		["SLIDER", ["Hesitation", "Maximum time (in seconds) that the unit will hesitate for after being confronted"], [0, 5, 0, 1]]
+];
+
+if(!(isNull _unit)) then {
+	_controls deleteAt 0;
+} else {
+	_controls deleteAt 1;
+};
+
+
+[
+	"Surrender Chance",
+	_controls,
+	_onConfirm,
+	{},
+	_this
+] call zen_dialog_fnc_create;
+
+
+// TODO: Add possibility to DISABLE this behaviour once set

--- a/CrowsZA/functions/fn_surrenderChanceZeus.sqf
+++ b/CrowsZA/functions/fn_surrenderChanceZeus.sqf
@@ -14,7 +14,9 @@ private _onConfirm =
 	_in params [["_pos",[0,0,0],[[]],3], "_unit"];
 
 	private _units = if(isNull _unit) then {
-		units (_dialogResult deleteAt 0)
+		private _u = [];
+		{ _u insert [-1, units _x, true]; } forEach ((ASLToAGL _pos) nearEntities [["Man"], (_dialogResult deleteAt 0)]);
+		_u
 	} else {
 		units group _unit
 	};
@@ -32,7 +34,7 @@ private _onConfirm =
 };
 
 private _controls = [
-		["SIDES", "Side", east],
+		["SLIDER:RADIUS", ["Radius", "Apply this effect to all units in radius"], [1, 100, 30, 0, ASLtoAGL _pos, [1, 0, 0, 0.7]]],
 		["SLIDER", ["Confrontation Radius", "Radius within which pointing a weapon at the unit will trigger a response"], [5, 50, 15, 0]],
 		["SLIDER:PERCENT", "Surrender Chance", [0, 1, 0.33, 0]],
 		["CHECKBOX", ["Hold Fire", "Units will hold fire until confronted"], [true]],

--- a/CrowsZA/functions/fn_zeusRegister.sqf
+++ b/CrowsZA/functions/fn_zeusRegister.sqf
@@ -49,7 +49,7 @@ private _moduleList = [
     ["Resupply Player Loadouts",{_this call crowsZA_fnc_resupplyPlayerLoadouts}, "\CrowsZA\data\resupplyplayerloadout.paa"],
     ["Remove Radio/Bino",{_this call crowsZA_fnc_removeRadioBino}, "\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\call_ca.paa"],
     ["Strip Explosives",{_this call crowsZA_fnc_stripExplosivesZeus}, "\a3\ui_f\data\igui\cfg\simpletasks\types\destroy_ca.paa"],
-    ["Surrender Chance",{_this call crowsZA_fnc_surrenderChanceZeus}, "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_secure_ca.paa"],
+    ["Surrender Chance",{_this call crowsZA_fnc_surrenderChanceZeus}, "\a3\ui_f\data\igui\cfg\holdactions\holdAction_secure_ca.paa"],
     ["Set Teleport to Squadmember",{_this call crowsZA_fnc_setTeleportToSquadMemberZeus}, "\CrowsZA\data\tpToSquad.paa"]
 ];
 

--- a/CrowsZA/functions/fn_zeusRegister.sqf
+++ b/CrowsZA/functions/fn_zeusRegister.sqf
@@ -49,6 +49,7 @@ private _moduleList = [
     ["Resupply Player Loadouts",{_this call crowsZA_fnc_resupplyPlayerLoadouts}, "\CrowsZA\data\resupplyplayerloadout.paa"],
     ["Remove Radio/Bino",{_this call crowsZA_fnc_removeRadioBino}, "\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\call_ca.paa"],
     ["Strip Explosives",{_this call crowsZA_fnc_stripExplosivesZeus}, "\a3\ui_f\data\igui\cfg\simpletasks\types\destroy_ca.paa"],
+    ["Surrender Chance",{_this call crowsZA_fnc_surrenderChanceZeus}, "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_secure_ca.paa"],
     ["Set Teleport to Squadmember",{_this call crowsZA_fnc_setTeleportToSquadMemberZeus}, "\CrowsZA\data\tpToSquad.paa"]
 ];
 


### PR DESCRIPTION
Add module to make units have a chance of surrendering when threatened; zeus can set activation radius, chance of unit surrendering (or opening fire), hesitation time, and whether a unit should hold fire until confronted.

Uses remote exec to check the cursor of each player in the created trigger's radius.

Possible TODOs:
- Option to remove this behaviour once set
- Replace "unit" param to fn_surrenderChance with "group" param, to emphasise that it will affect the stance of an entire group