### PR TITLE
BugFix - CBA Settings not saved on server.

### DIFF
--- a/CrowsZA/functions/fn_registerSettingsCBA.sqf
+++ b/CrowsZA/functions/fn_registerSettingsCBA.sqf
@@ -15,8 +15,8 @@ if !(isClass (configFile >> "CfgPatches" >> "cba_main")) exitWith
 	diag_log "[Crows Zeus Additions]: CBA not detected.";
 };
 
-// only load for players
-if (!hasInterface) exitWith {};
+// only load for players and dedicated server (for save settings)
+if (!hasInterface && !isDedicated) exitWith {};
 
 // register CBA keybinding to toggle zeus-drawn text
 [


### PR DESCRIPTION
**When merged this pull request will:**
- _Add a !isDedicated check for CBA settings registration._
- _This change acts as a fix for a bug where CBA settings are not saved on the dedicated server._

CBA settings need to be loaded on the dedicated server (to save the settings) not only for player.
In the current release version, settings can be saved on the client host and the player, but this does not work on the dedicated server.
Therefore, add a check for "!isDedicated" so that these settings can be used by the player and client host and dedicated server.
After this change, only headless clients and AI will no longer load settings.