### PR TITLE
Added a simplified Chinese translation in Stringtable.xml

### DIFF
--- a/addons/ace/stringtable.xml
+++ b/addons/ace/stringtable.xml
@@ -1,137 +1,181 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="Crows Zeus Additions">
-      <Package name="ace">
-            <Key ID="STR_CROWSZA_ACE_module_add_damage">
-                  <English>ACE Add Damage to Unit</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_module_unconscious_toggle">
-                  <English>Mass-Unconscious Toggle</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_module_capture_player">
-                  <English>Capture Player</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_module_mass_surrender">
-                  <English>Mass-Surrender Toggle</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_module_supply_vic">
-                  <English>Set Supply Vehicle</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_module_jshk">
-                  <English>JSHK Heal</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_supplyvic_name">
-                  <English>Set vehicle as...</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_supplyvic_rearm">
-                  <English>Rearm</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_supplyvic_rearm_tooltip">
-                  <English>Set vehicle as rearm vehicle</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_supplyvic_repair">
-                  <English>Repair</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_supplyvic_repair_tooltip">
-                  <English>Set vehicle as repair vehicle</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_supplyvic_refuel">
-                  <English>Refuel</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_supplyvic_refuel_tooltip">
-                  <English>Set vehicle as refuel vehicle</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_supplyvic_refuel_amount">
-                  <English>Refuel Amount [liters]</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_massunconscious_name">
-                  <English>Mass Unconscious</English>
-            </Key>            
-            <Key ID="STR_CROWSZA_ACE_massunconscious_units">
-                  <English>Units</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_masssurrender_name">
-                  <English>Mass Surrender/Captive</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_masssurrender_action">
-                  <English>Action</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_masssurrender_surrender">
-                  <English>Surrender</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_masssurrender_captive">
-                  <English>Captive</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_name">
-                  <English>Add ACE Damage to Unit</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_bodypart">
-                  <English>Body Part</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_head">
-                  <English>Head</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_body">
-                  <English>Body</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_leg_l">
-                  <English>Left Leg</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_leg_r">
-                  <English>Right Leg</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_hand_l">
-                  <English>Left Hand</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_hand_r">
-                  <English>Right Hand</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_falling">
-                  <English>Falling</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_ropeburn">
-                  <English>Ropeburn</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_vehiclecrash">
-                  <English>Vehiclecrash</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_collision">
-                  <English>Collision</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_unknown">
-                  <English>Unkown</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_explosive">
-                  <English>Explosive</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_grenade">
-                  <English>Grenade</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_shell">
-                  <English>Shell</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_bullet">
-                  <English>Bullet</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_backblast">
-                  <English>Backblast</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_bite">
-                  <English>Bite</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_punch">
-                  <English>Punch</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_stab">
-                  <English>Stab</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_drowning">
-                  <English>Drowning</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_burn">
-                  <English>Burn</English>
-            </Key>
-            <Key ID="STR_CROWSZA_ACE_adddamage_damage">
-                  <English>Damage</English>
-            </Key>
-      </Package>
+    <Package name="ace">
+        <Key ID="STR_CROWSZA_ACE_module_add_damage">
+            <English>ACE Add Damage to Unit</English>
+            <Chinesesimp>ACE - 为单位增加 ACE 伤害</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_module_unconscious_toggle">
+            <English>Mass-Unconscious Toggle</English>
+            <Chinesesimp>ACE - 无意识切换</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_module_capture_player">
+            <English>Capture Player</English>
+            <Chinesesimp>ACE - 抓捕玩家</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_module_mass_surrender">
+            <English>Mass-Surrender Toggle</English>
+            <Chinesesimp>ACE - 集体投降切换</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_module_supply_vic">
+            <English>Set Supply Vehicle</English>
+            <Chinesesimp>ACE - 设置补给车</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_module_jshk">
+            <English>JSHK Heal</English>
+            <Chinesesimp>JSHK Heal</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_supplyvic_name">
+            <English>Set vehicle as...</English>
+            <Chinesesimp>将车辆设置为...</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_supplyvic_rearm">
+            <English>Rearm</English>
+            <Chinesesimp>重新武装</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_supplyvic_rearm_tooltip">
+            <English>Set vehicle as rearm vehicle</English>
+            <Chinesesimp>将车辆设置为重新武装车辆</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_supplyvic_repair">
+            <English>Repair</English>
+            <Chinesesimp>修理</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_supplyvic_repair_tooltip">
+            <English>Set vehicle as repair vehicle</English>
+            <Chinesesimp>将车辆设置为修理车</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_supplyvic_refuel">
+            <English>Refuel</English>
+            <Chinesesimp>加油</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_supplyvic_refuel_tooltip">
+            <English>Set vehicle as refuel vehicle</English>
+            <Chinesesimp>将车辆设置为加油车</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_supplyvic_refuel_amount">
+            <English>Refuel Amount [liters]</English>
+            <Chinesesimp>为加油车设置油量 [升]</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_massunconscious_name">
+            <English>Mass Unconscious</English>
+            <Chinesesimp>ACE - 无意识切换菜单</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_massunconscious_units">
+            <English>Units</English>
+            <Chinesesimp>单位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_masssurrender_name">
+            <English>Mass Surrender/Captive</English>
+            <Chinesesimp>ACE - 集体投降切换菜单</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_masssurrender_action">
+            <English>Action</English>
+            <Chinesesimp>行动</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_masssurrender_surrender">
+            <English>Surrender</English>
+            <Chinesesimp>投降</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_masssurrender_captive">
+            <English>Captive</English>
+            <Chinesesimp>俘虏</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_name">
+            <English>Add ACE Damage to Unit</English>
+            <Chinesesimp>ACE - 为单位增加 ACE 伤害菜单</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_bodypart">
+            <English>Body Part</English>
+            <Chinesesimp>身体部位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_head">
+            <English>Head</English>
+            <Chinesesimp>头</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_body">
+            <English>Body</English>
+            <Chinesesimp>身体</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_leg_l">
+            <English>Left Leg</English>
+            <Chinesesimp>左腿</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_leg_r">
+            <English>Right Leg</English>
+            <Chinesesimp>右腿</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_hand_l">
+            <English>Left Hand</English>
+            <Chinesesimp>左手</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_bodypart_hand_r">
+            <English>Right Hand</English>
+            <Chinesesimp>右手</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_falling">
+            <English>Falling</English>
+            <Chinesesimp>坠落</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_ropeburn">
+            <English>Ropeburn</English>
+            <Chinesesimp>Ropeburn</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_vehiclecrash">
+            <English>Vehiclecrash</English>
+            <Chinesesimp>车辆撞击</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_collision">
+            <English>Collision</English>
+            <Chinesesimp>碰撞</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_unknown">
+            <English>Unkown</English>
+            <Chinesesimp>未知</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_explosive">
+            <English>Explosive</English>
+            <Chinesesimp>爆炸</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_grenade">
+            <English>Grenade</English>
+            <Chinesesimp>手榴弹</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_shell">
+            <English>Shell</English>
+            <Chinesesimp>炮轰</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_bullet">
+            <English>Bullet</English>
+            <Chinesesimp>子弹</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_backblast">
+            <English>Backblast</English>
+            <Chinesesimp>反向爆破</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_bite">
+            <English>Bite</English>
+            <Chinesesimp>咬</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_punch">
+            <English>Punch</English>
+            <Chinesesimp>被揍</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_stab">
+            <English>Stab</English>
+            <Chinesesimp>捅</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_drowning">
+            <English>Drowning</English>
+            <Chinesesimp>溺水</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_burn">
+            <English>Burn</English>
+            <Chinesesimp>烧伤</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_ACE_adddamage_damage">
+            <English>Damage</English>
+            <Chinesesimp>损坏</Chinesesimp>
+        </Key>
+    </Package>
 </Project>

--- a/addons/drawbuild/stringtable.xml
+++ b/addons/drawbuild/stringtable.xml
@@ -1,41 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="Crows Zeus Additions">
-      <Package name="drawbuild">
-            <Key ID="STR_CROWSZA_Drawbuild_module_name">
-                  <English>DrawBuild</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_build_to_here">
-                  <English>Build to here</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_start_pos">
-                  <English>Start Position</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_filter">
-                  <English>Filter</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_error_unknown_object">
-                  <English>"Object not recognised:&lt;br/&gt;%1"</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_objects_to_build">
-                  <English>Select Object To Build</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_custom_object">
-                  <English>Custom Object</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_custom_object_tooltip">
-                  <English>classname of an object to be used&lt;br/&gt;The smaller the object, the more will be created&lt;br/&gt;Warning: behaviour is experimental and not guaranteed!</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_custom_offset">
-                  <English>Offset</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_custom_offset_tooltip">
-                  <English>Distance to offset each object by&lt;br/&gt;Smaller distance results in overlapping objects; larger distance results in spacing between objects&lt;br/&gt;Leave empty for default offset</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_enable_simulation">
-                  <English>Enable Simulation</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Drawbuild_enable_damage">
-                  <English>Enable Damage</English>
-            </Key>
-      </Package>
+    <Package name="drawbuild">
+        <Key ID="STR_CROWSZA_Drawbuild_module_name">
+            <English>DrawBuild</English>
+            <Chinesesimp>建造</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Drawbuild_build_to_here">
+            <English>Build to here</English>
+            <Chinesesimp>建造到此处</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Drawbuild_start_pos">
+            <English>Start Position</English>
+            <Chinesesimp>起始位置</Chinesesimp>
+        </Key>
+		<Key ID="STR_CROWSZA_Drawbuild_filter">
+            <English>Filter</English>
+            <Chinesesimp>筛选器</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Drawbuild_error_unknown_object">
+            <English>"Object not recognised:&lt;br/&gt;%1"</English>
+            <Chinesesimp>"未识别的对象:&lt;br/&gt;%1"</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Drawbuild_objects_to_build">
+            <English>Select Object To Build</English>
+            <Chinesesimp>选择要建造的对象</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Drawbuild_custom_object">
+            <English>Custom Object</English>
+            <Chinesesimp>自定义对象</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Drawbuild_custom_object_tooltip">
+            <English>classname of an object to be used&lt;br/&gt;The smaller the object, the more will be created&lt;br/&gt;Warning: behaviour is experimental and not guaranteed!</English>
+            <Chinesesimp>要使用的对象的类名&lt;br/&gt;对象越小,创建的就越多&lt;br/&gt;警告:行为是实验性的,无法保证!</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Drawbuild_custom_offset">
+            <English>Offset</English>
+            <Chinesesimp>偏移量</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Drawbuild_custom_offset_tooltip">
+			<English>Distance to offset each object by&lt;br/&gt;Smaller distance results in overlapping objects; larger distance results in spacing between objects&lt;br/&gt;Leave empty for default offset</English>
+            <Chinesesimp>用于偏移每个对象的距离&lt;br/&gt;留空以使用默认偏移量&lt;br/&gt;</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Drawbuild_enable_simulation">
+            <English>Enable Simulation</English>
+            <Chinesesimp>启用模拟</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Drawbuild_enable_damage">
+            <English>Enable Damage</English>
+            <Chinesesimp>启用伤害</Chinesesimp>
+        </Key>
+    </Package>
 </Project>

--- a/addons/misc/stringtable.xml
+++ b/addons/misc/stringtable.xml
@@ -1,718 +1,953 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="Crows Zeus Additions">
-      <Package name="misc">
-            <Key ID="STR_CROWSZA_Misc_activate_on_death">
-                  <English>Activate On Death</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_activate_on_death">
-                  <English>Remove Activate On Death</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_trees">
-                  <English>Remove Trees</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_restore_trees">
-                  <English>Restore Trees</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_follow_unit_animals">
-                  <English>Follow Unit With Animal</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_delete_follow_unit_animals">
-                  <English>Delete All Follow Animals</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_spawn_arsenal">
-                  <English>Spawn Arsenal</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_set_numberplate">
-                  <English>Set Numberplate</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_delete_all_dead">
-                  <English>Delete ALL dead</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_set_colour">
-                  <English>Set Colour</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support">
-                  <English>Fire Support</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_player_loadouts">
-                  <English>Resupply Player Loadouts</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_bino_radio">
-                  <English>Remove Radio/Bino</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_spawn_ied_clutter">
-                  <English>Spawn IED Clutter</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives">
-                  <English>Strip Explosives</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance">
-                  <English>Surrender Chance</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_camera_center_unit">
-                  <English>Camera Center Unit</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_paste_loadout">
-                  <English>Paste Loadout</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_view">
-                  <English>View</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_radius_heal">
-                  <English>Radius Heal</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_10m">
-                  <English>10m</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_50m">
-                  <English>50m</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_100m">
-                  <English>100m</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_150m">
-                  <English>150m</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_200m">
-                  <English>200m</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_toggle_pathing">
-                  <English>Toggle Pathing</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_on">
-                  <English>On</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_off">
-                  <English>Off</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_toggle">
-                  <English>Toggle</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_unit">
-                  <English>Unit</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_group">
-                  <English>Group</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_side">
-                  <English>Side</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_blufor">
-                  <English>BLUFOR</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_opfor">
-                  <English>OPFOR</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_indfor">
-                  <English>INDFOR</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_civ">
-                  <English>CIV</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled">
-                  <English>Activate On Death</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_error_unit">
-                  <English>Must be placed on a unit or object</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_error_hint">
-                  <English>Something has gone wrong (no unit)!</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_error_null">
-                  <English>Nothing set - no action taken!</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_error_empty">
-                  <English>No on-killed-module events to remove!</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_hint_killer">
-                  <English>Hint (Killer)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_hint_killer_tooltip">
-                  <English>Display a hint to the player that killed the unit</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_hint_all">
-                  <English>Hint (All)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_hint_all_tooltip">
-                  <English>Display a hint to all players</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_hint_zeus">
-                  <English>Hint (Zeus)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_hint_zeus_tooltip">
-                  <English>Display a hint to (all) Zeus players</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_delete_remains">
-                  <English>Delete Remains</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_hint_delete_remains_tooltip">
-                  <English>Delete the 'dead' object or unit</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_explosion">
-                  <English>Explosion</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_hint_explosion_tooltip">
-                  <English>Detonate an explosive on the position of the killed unit</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_explosion_none">
-                  <English>None</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_explosion_small">
-                  <English>Small</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_explosion_large">
-                  <English>Large</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_explosion_nuclear">
-                  <English>Nuclear</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_emp">
-                  <English>EMP</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_emp_tooltip">
-                  <English>Detonate an EMP that affects lights, radios, unprotected vehicles,&lt;br/&gt;and other electronic equipment within 500m</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_sound_killer">
-                  <English>Sound (Killer)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_sound_killer_tooltip">
-                  <English>Play a sound to the player that killed the unit</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_sound_all">
-                  <English>Sound (All)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_sound_all_tooltip">
-                  <English>Play a sound to all players</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_customcode">
-                  <English>Custom Code</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_customcode_tooltip">
-                  <English>Custom code to execute on unit's death&lt;br/&gt;Arguments: _unit, _killer, _instigator, _useEffects&lt;br/&gt;Written at your own risk - if unsure, leave blank!</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_codetarget">
-                  <English>Code Target</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_codetarget_tooltip">
-                  <English>Which machine(s) to run the custom code on</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_codetarget_client">
-                  <English>Clients</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_codetarget_server">
-                  <English>Server</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_onkilled_codetarget_clientserver">
-                  <English>Clients + Server</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance_name">
-                  <English>Surrender Chance</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance_hesitation">
-                  <English>Hesitation</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance_hesitation_tooltip">
-                  <English>Maximum time (in seconds) that the unit will hesitate for after being confronted</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance_hold_fire">
-                  <English>Hold Fire</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance_hold_fire_tooltip">
-                  <English>Units will hold fire until confronted</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance_confrontation_radius">
-                  <English>Confrontation Radius</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance_confrontation_radius_tooltip">
-                  <English>Radius within which pointing a weapon at the unit will trigger a response</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance_radius">
-                  <English>Radius</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance_radius_tooltip">
-                  <English>Apply this effect to all units in radius</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_surrender_chance_error">
-                  <English>Surrender chance already applied to this unit</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_error">
-                  <English>Unrecognised custom replacement</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_ied_amount">
-                  <English>IED Amount</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_ied_size">
-                  <English>IED Size</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_small">
-                  <English>Small</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_medium">
-                  <English>Medium</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_large">
-                  <English>Large</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_random">
-                  <English>Random</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_max_clutter_size">
-                  <English>Max Clutter Size</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_density">
-                  <English>Density</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_radius">
-                  <English>Radius</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_name">
-                  <English>Spawn IED Clutter</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_ied_type">
-                  <English>IED Type</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_ied_type_tooltip">
-                  <English>"Clutter" transforms a random object of clutter into an IED</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_urban">
-                  <English>Urban</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_clutter">
-                  <English>Clutter</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_ied_clutter_dug_in">
-                  <English>Dug-in</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_numberplate_name">
-                  <English>Set Numberplate</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_numberplate_text">
-                  <English>Text</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_set_colour_reset">
-                  <English>RESET</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_set_colour_reset_tooltip">
-                  <English>Resets Texture to default</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_set_colour_apply_textures">
-                  <English>Apply to all textures</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_set_colour_apply_textures_tooltip">
-                  <English>Adds the colour to all textures</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_set_colour_colour">
-                  <English>Colour</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_set_colour_texture">
-                  <English>Texture</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_error">
-                  <English>Classname provided does not exist!</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_multiplier">
-                  <English>Set multipler for ammo supply</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_ace_rearm">
-                  <English>ACE Rearm</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_ace_rearm_tooltip">
-                  <English>Set as ACE Rearm vehicle</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_medical">
-                  <English>Medical</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_medical_tooltip">
-                  <English>Add Medical supplies</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_airdrop_height">
-                  <English>Airdrop height [m]</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_flyfrom">
-                  <English>Fly From</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_N">
-                  <English>N</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_NE">
-                  <English>NE</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_E">
-                  <English>E</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_SE">
-                  <English>SE</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_S">
-                  <English>S</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_SW">
-                  <English>SW</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_W">
-                  <English>W</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_NW">
-                  <English>NW</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_custom_type">
-                  <English>Custom Type (Optional)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_custom_type_tooltip">
-                  <English>Provide classname to aircraft you want to use, instead of using dropdown list</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_choose_aircraft">
-                  <English>Choose Aircraft</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_choose_aircraft_tooltip">
-                  <English>What aircraft to drop the supply from</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_aircraft">
-                  <English>Aircraft</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_aircraft_tooltip">
-                  <English>Make aircraft drop it</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_airdrop">
-                  <English>Airdrop</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_airdrop_tooltip">
-                  <English>Make it airdrop from 300m</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_resupply_loadouts_multiplier_dialog">
-                  <English>Multiplier (amount per player)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_restore_trees_dialog">
-                  <English>Restore Trees and bushes in radius</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_restore_trees_radius">
-                  <English>Radius</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_restore_trees_trees">
-                  <English>Trees</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_restore_trees_trees_tooltip">
-                  <English>Enable restoration of trees</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_restore_trees_bushes">
-                  <English>Bushes</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_restore_trees_bushes_tooltip">
-                  <English>Enable restoration of bushes</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_restore_trees_stones">
-                  <English>Stones</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_restore_trees_stones_tooltip">
-                  <English>Enable restoration of stones</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_trees_dialog">
-                  <English>Remove terrain objects selected in radius</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_trees_stones_tooltip">
-                  <English>Enable removal of stones</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_trees_bushes_tooltip">
-                  <English>Enable removal of bushes</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_trees_trees_tooltip">
-                  <English>Enable removal of trees</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_radio_bino_error">
-                  <English>Zeus has removed your radio and/or binoculars</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_radio_bino">
-                  <English>Remove Equipment</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_radio_bino_remove_bino">
-                  <English>Remove Binoculars</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_radio_bino_remove_bino_tooltip">
-                  <English>Removes binoculars from units binocular slot</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_radio_bino_remove_radio">
-                  <English>Remove Radio</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_radio_bino_remove_radio_tooltip">
-                  <English>Removes radios from units radio slot</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_radio_bino_group">
-                  <English>Entire Group</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_radio_bino_group_tooltip">
-                  <English>Applies to entire group, or only unit selected</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_remove_radio_bino_side">
-                  <English>Side</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_radius_to_heal">
-                  <English>Radius to heal</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_loadout">
-                  <English>Loadout</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_SL">
-                  <English>SL</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_weight">
-                  <English>Weight</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_dialog">
-                  <English>Select Firesupport Type and Area</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_type">
-                  <English>Type</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_custom_type">
-                  <English>Custom Type (ex.)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_seconds_salvo">
-                  <English>Seconds between Salvos</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_start_after">
-                  <English>Start after ... seconds</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_stop_after">
-                  <English>Stop After Salvos (0 = indef.)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_guns">
-                  <English>Guns</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_display_radius">
-                  <English>Display Radius (only &lt;=200m)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_mortar">
-                  <English>82 mm Mortar</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_howitzer">
-                  <English>155 mm Howitzer</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_rocket">
-                  <English>230 mm Rocket</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_flare_white">
-                  <English>Flare 40mm White</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_fire_support_smoke_white">
-                  <English>Smoke 120mm White</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_delete_dead">
-                  <English>Are you sure you want to delete ALL dead?</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_delete_bodies">
-                  <English>Delete Bodies</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_delete_bodies_tooltip">
-                  <English>Deletes all dead bodies not inside vehicles</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_delete_wrecks">
-                  <English>Delete Wrecks</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_delete_wrecks_tooltip">
-                  <English>Deletes all wrecks and any crew inside</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_delete_animal_followers">
-                  <English>Are you sure you will delete all animals following people?</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_ignore_players">
-                  <English>Ignore players</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_removed">
-                  <English>removed</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_replaced">
-                  <English>replaced</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_zeus_has_removed">
-                  <English>Zeus has %1 your %2</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_whole_group">
-                  <English>Whole Group</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_whole_group_tooltip">
-                  <English>Remove items from this unit's group</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_item_type">
-                  <English>Item Type</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_item_type_tooltip">
-                  <English>"Signals" includes smoke grenades, chemlights, IR strobes, and UGL smokes.&lt;br/&gt;"UGL" includes explosive ammo for under-barrel and dedicated grenade launchers</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_signals">
-                  <English>Signals</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_grenades">
-                  <English>Grenades</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_explosives">
-                  <English>Explosives</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_ugl">
-                  <English>UGL</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_launchers">
-                  <English>Launchers</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_replace_with">
-                  <English>Replace with</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_replace_with_custom">
-                  <English>Replace with (custom)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_replace_with_custom_tooltip">
-                  <English>A custom magazine or item to replace with&lt;br/&gt;(Must be in "CfgMagazines" or inherit from "ItemCore")</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_leave_untouched">
-                  <English>Leave untouched</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_leave_untouched_tooltip">
-                  <English>Amount of unit's inventory to leave unchanged.&lt;br/&gt;Does not guarantee which type is preserved if the unit has, e.g. multiple colours of smoke.</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_strip_explosives_dialog">
-                  <English>Remove Explosives</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke">
-                  <English>Suitcase Device</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_edit">
-                  <English>Edit Suitcase Device</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_error_zeusPlacement">
-                  <English>Must be place on an existing Device, or nothing</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuse">
-                  <English>Defuse Device</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_none">
-                  <English>Nothing</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_explosion_small">
-                  <English>Explosion (Small)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_explosion_large">
-                  <English>Explosion (Large)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_explosion_nuclear">
-                  <English>Explosion (Nuclear)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_smoke_red">
-                  <English>Smoke (Red)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_smoke_yellow">
-                  <English>Smoke (Yellow)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_emp">
-                  <English>EMP</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_timer">
-                  <English>Timer</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_timer_tooltip">
-                  <English>How long until the device activates in MM:SS</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect">
-                  <English>Effect</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_tooltip">
-                  <English>What happens when the device activates</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable">
-                  <English>Defusable</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable_tooltip">
-                  <English>Who can attempt to defuse the device</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable_noone">
-                  <English>No-one</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable_specialist">
-                  <English>Explosive Specialists</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable_engineer">
-                  <English>Engineers</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable_any">
-                  <English>Anyone</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defusetimer">
-                  <English>Defuse Time</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defusetimer_tooltip">
-                  <English>How long does it take to defuse the device in MM:SS</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_armed">
-                  <English>Armed</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_suitcaseNuke_armed_tooltip">
-                  <English>Whether the device can be detonated&lt;br/&gt;If not armed, countdown is paused</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_follow_animal">
-                  <English>Select Animal Type</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal">
-                  <English>Animal</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_dog">
-                  <English>Dog</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_sheep">
-                  <English>Sheep</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_goat">
-                  <English>Goat</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_rabbit">
-                  <English>Rabbit</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_hen">
-                  <English>Hen</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_snake">
-                  <English>Snake</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_amount">
-                  <English>Amount</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_spawn_offset">
-                  <English>Spawn offset [m]</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_spawn_offset_tooltip">
-                  <English>How far away in random direction the animals should spawn</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_scale">
-                  <English>Scale*</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_scale_tooltip">
-                  <English>Experimental feature that doesn't always work. Works best on snakes</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_invincible">
-                  <English>Set Invincible</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_attack_nearby">
-                  <English>Attack Nearby Units</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_pet_animal">
-                  <English>Pet</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_sound_dog">
-                  <English>WOOF</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_sound_sheep">
-                  <English>MÆÆÆÆÆHH</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_sound_goat">
-                  <English>MAAAAA..Mariner..AAAA</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_sound_rabbit">
-                  <English>PUUUUUUURRRRR</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_sound_hen">
-                  <English>CLUCK-CLUCK</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Misc_animal_sound_snake">
-                  <English>HISSSSS, No Step On Snek!</English>
-            </Key>
-      </Package>
+    <Package name="misc">
+        <Key ID="STR_CROWSZA_Misc_activate_on_death">
+            <English>Activate On Death</English>
+            <Chinesesimp>死亡时激活</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_activate_on_death">
+            <English>Remove Activate On Death</English>
+            <Chinesesimp>移除死亡时激活</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_trees">
+            <English>Remove Trees</English>
+            <Chinesesimp>杂项 - 移除树木</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_restore_trees">
+            <English>Restore Trees</English>
+            <Chinesesimp>杂项 - 恢复树木</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_follow_unit_animals">
+            <English>Follow Unit With Animal</English>
+            <Chinesesimp>杂项 - 生成跟随动物</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_delete_follow_unit_animals">
+            <English>Delete All Follow Animals</English>
+            <Chinesesimp>杂项 - 删除所有跟随动物</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_spawn_arsenal">
+            <English>Spawn Arsenal</English>
+            <Chinesesimp>杂项 - 生成军火库</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_set_numberplate">
+            <English>Set Numberplate</English>
+            <Chinesesimp>杂项 - 设置车牌号</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_delete_all_dead">
+            <English>Delete ALL dead</English>
+            <Chinesesimp>杂项 - 删除所有死亡单位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_set_colour">
+            <English>Set Colour</English>
+            <Chinesesimp>杂项 - 设置颜色</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support">
+            <English>Fire Support</English>
+            <Chinesesimp>杂项 - 火力支援</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_player_loadouts">
+            <English>Resupply Player Loadouts</English>
+            <Chinesesimp>杂项 - 补给玩家装备</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_bino_radio">
+            <English>Remove Radio/Bino</English>
+            <Chinesesimp>杂项 - 移除 无线电/Bino</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_spawn_ied_clutter">
+            <English>Spawn IED Clutter</English>
+            <Chinesesimp>杂项 - 生成 IED 杂物</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives">
+            <English>Strip Explosives</English>
+            <Chinesesimp>杂项 - Strip 爆炸物</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance">
+            <English>Surrender Chance</English>
+            <Chinesesimp>杂项 - 投降的机会</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_camera_center_unit">
+            <English>Camera Center Unit</English>
+            <Chinesesimp>摄像机中心单位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_paste_loadout">
+            <English>Paste Loadout</English>
+            <Chinesesimp>粘贴装备</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_view">
+            <English>View</English>
+            <Chinesesimp>查看</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_radius_heal">
+            <English>Radius Heal</English>
+            <Chinesesimp>半径治疗</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_10m">
+            <English>10m</English>
+            <Chinesesimp>10m</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_50m">
+            <English>50m</English>
+            <Chinesesimp>50m</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_100m">
+            <English>100m</English>
+            <Chinesesimp>100m</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_150m">
+            <English>150m</English>
+            <Chinesesimp>150m</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_200m">
+            <English>200m</English>
+            <Chinesesimp>200m</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_toggle_pathing">
+            <English>Toggle Pathing</English>
+            <Chinesesimp>切换路径</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_on">
+            <English>On</English>
+            <Chinesesimp>开启</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_off">
+            <English>Off</English>
+            <Chinesesimp>关闭</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_toggle">
+            <English>Toggle</English>
+            <Chinesesimp>切换</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_unit">
+            <English>Unit</English>
+            <Chinesesimp>单位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_group">
+            <English>Group</English>
+            <Chinesesimp>小组</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_side">
+            <English>Side</English>
+            <Chinesesimp>侧面</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_blufor">
+            <English>BLUFOR</English>
+            <Chinesesimp>BLUFOR</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_opfor">
+            <English>OPFOR</English>
+            <Chinesesimp>OPFOR</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_indfor">
+            <English>INDFOR</English>
+            <Chinesesimp>INDFOR</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_civ">
+            <English>CIV</English>
+            <Chinesesimp>CIV</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled">
+            <English>Activate On Death</English>
+            <Chinesesimp>在死亡时激活</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_error_unit">
+            <English>Must be placed on a unit or object</English>
+            <Chinesesimp>必须放置在单位或对象上</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_error_hint">
+            <English>Something has gone wrong (no unit)!</English>
+            <Chinesesimp>发生了错误 (没有单位)!</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_error_null">
+            <English>Nothing set - no action taken!</English>
+            <Chinesesimp>未设置任何内容 - 不采取任何行动!</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_error_empty">
+            <English>No on-killed-module events to remove!</English>
+            <Chinesesimp>没有可移除的"被杀时"模块事件!</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_hint_killer">
+            <English>Hint (Killer)</English>
+            <Chinesesimp>提示(杀手)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_hint_killer_tooltip">
+            <English>Display a hint to the player that killed the unit</English>
+            <Chinesesimp>向杀死单位的玩家显示提示</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_hint_all">
+            <English>Hint (All)</English>
+            <Chinesesimp>提示(所有人)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_hint_all_tooltip">
+            <English>Display a hint to all players</English>
+            <Chinesesimp>向所有玩家显示提示</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_hint_zeus">
+            <English>Hint (Zeus)</English>
+            <Chinesesimp>提示(宙斯)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_hint_zeus_tooltip">
+            <English>Display a hint to (all) Zeus players</English>
+            <Chinesesimp>向(所有)宙斯玩家显示提示</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_delete_remains">
+            <English>Delete Remains</English>
+            <Chinesesimp>删除残留</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_hint_delete_remains_tooltip">
+            <English>Delete the 'dead' object or unit</English>
+            <Chinesesimp>删除‘死亡’的物体或单位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_explosion">
+            <English>Explosion</English>
+            <Chinesesimp>爆炸</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_hint_explosion_tooltip">
+            <English>Detonate an explosive on the position of the killed unit</English>
+            <Chinesesimp>在被杀死单位的位置引爆爆炸物</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_explosion_none">
+            <English>None</English>
+            <Chinesesimp>无</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_explosion_small">
+            <English>Small</English>
+            <Chinesesimp>小型</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_explosion_large">
+            <English>Large</English>
+            <Chinesesimp>大型</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_explosion_nuclear">
+            <English>Nuclear</English>
+            <Chinesesimp>核</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_emp">
+            <English>EMP</English>
+            <Chinesesimp>电磁脉冲</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_emp_tooltip">
+            <English>Detonate an EMP that affects lights, radios, unprotected vehicles,&lt;br/&gt;and other electronic equipment within 500m</English>
+            <Chinesesimp>引爆电磁脉冲，影响 500 米范围内的灯光、无线电、无保护车辆&lt;br/&gt;和 500 米内的其他电子设备</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_sound_killer">
+            <English>Sound (Killer)</English>
+            <Chinesesimp>声音 (杀手)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_sound_killer_tooltip">
+            <English>Play a sound to the player that killed the unit</English>
+            <Chinesesimp>向杀死单位的玩家播放声音</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_sound_all">
+            <English>Sound (All)</English>
+            <Chinesesimp>声音 (所有人)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_sound_all_tooltip">
+            <English>Play a sound to all players</English>
+            <Chinesesimp>向所有玩家播放声音</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_customcode">
+            <English>Custom Code</English>
+            <Chinesesimp>自定义代码</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_customcode_tooltip">
+            <English>Custom code to execute on unit's death&lt;br/&gt;Arguments: _unit, _killer, _instigator, _useEffects&lt;br/&gt;Written at your own risk - if unsure, leave blank!</English>
+            <Chinesesimp>单位死亡时执行的自定义代码&lt;br/&gt;参数:单位,_杀手,_执行者,_使用效果&lt;br/&gt;风险自负--如果不确定,请留空!</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_codetarget">
+            <English>Code Target</English>
+            <Chinesesimp>代码目标</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_codetarget_tooltip">
+            <English>Which machine(s) to run the custom code on</English>
+            <Chinesesimp>在哪个机器上运行自定义代码</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_codetarget_client">
+            <English>Clients</English>
+            <Chinesesimp>客户端</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_codetarget_server">
+            <English>Server</English>
+            <Chinesesimp>服务器</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_onkilled_codetarget_clientserver">
+            <English>Clients + Server</English>
+            <Chinesesimp>客户端 + 服务器</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance_name">
+            <English>Surrender Chance</English>
+            <Chinesesimp>投降的机会</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance_hesitation">
+            <English>Hesitation</English>
+            <Chinesesimp>犹豫</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance_hesitation_tooltip">
+            <English>Maximum time (in seconds) that the unit will hesitate for after being confronted</English>
+            <Chinesesimp>单位在面对面后犹豫的最长时间(以秒为单位)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance_hold_fire">
+            <English>Hold Fire</English>
+            <Chinesesimp>保持火力</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance_hold_fire_tooltip">
+            <English>Units will hold fire until confronted</English>
+            <Chinesesimp>单位将保持火力直到被对抗</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance_confrontation_radius">
+            <English>Confrontation Radius</English>
+            <Chinesesimp>对抗半径</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance_confrontation_radius_tooltip">
+            <English>Radius within which pointing a weapon at the unit will trigger a response</English>
+            <Chinesesimp>将武器指向该单位将触发响应的半径</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance_radius">
+            <English>Radius</English>
+            <Chinesesimp>半径</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance_radius_tooltip">
+            <English>Apply this effect to all units in radius</English>
+            <Chinesesimp>将此效果应用于半径内的所有单位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_surrender_chance_error">
+            <English>Surrender chance already applied to this unit</English>
+            <Chinesesimp>投降概率已应用于该单位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_error">
+            <English>Unrecognised custom replacement</English>
+            <Chinesesimp>无法识别的自定义替换</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_ied_amount">
+            <English>IED Amount</English>
+            <Chinesesimp>IED的数量</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_ied_size">
+            <English>IED Size</English>
+            <Chinesesimp>IED的尺寸</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_small">
+            <English>Small</English>
+            <Chinesesimp>小型</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_medium">
+            <English>Medium</English>
+            <Chinesesimp>中型</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_large">
+            <English>Large</English>
+            <Chinesesimp>大型</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_random">
+            <English>Random</English>
+            <Chinesesimp>随机</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_max_clutter_size">
+            <English>Max Clutter Size</English>
+            <Chinesesimp>生成杂物的范围</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_density">
+            <English>Density</English>
+            <Chinesesimp>密度</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_radius">
+            <English>Radius</English>
+            <Chinesesimp>半径</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_name">
+            <English>Spawn IED Clutter</English>
+            <Chinesesimp>生成 IED 杂物菜单</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_ied_type">
+            <English>IED Type</English>
+            <Chinesesimp>IED 类型</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_ied_type_tooltip">
+            <English>"Clutter" transforms a random object of clutter into an IED</English>
+            <Chinesesimp>"杂物"可将杂乱无章的随机物体变成IED</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_urban">
+            <English>Urban</English>
+            <Chinesesimp>城市</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_clutter">
+            <English>Clutter</English>
+            <Chinesesimp>杂乱</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_ied_clutter_dug_in">
+            <English>Dug-in</English>
+            <Chinesesimp>深挖</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_numberplate_name">
+            <English>Set Numberplate</English>
+            <Chinesesimp>设置车牌号菜单</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_numberplate_text">
+            <English>Text</English>
+            <Chinesesimp>号码</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_set_colour_reset">
+            <English>RESET</English>
+            <Chinesesimp>重置</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_set_colour_reset_tooltip">
+            <English>Resets Texture to default</English>
+            <Chinesesimp>将纹理重置为默认值</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_set_colour_apply_textures">
+            <English>Apply to all textures</English>
+            <Chinesesimp>适用于所有纹理</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_set_colour_apply_textures_tooltip">
+            <English>Adds the colour to all textures</English>
+            <Chinesesimp>为所有纹理添加颜色</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_set_colour_colour">
+            <English>Colour</English>
+            <Chinesesimp>颜色</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_set_colour_texture">
+            <English>Texture</English>
+            <Chinesesimp>纹理</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_error">
+            <English>Classname provided does not exist!</English>
+            <Chinesesimp>提供的类名不存在!</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_multiplier">
+            <English>Set multipler for ammo supply</English>
+            <Chinesesimp>设置玩家补给菜单</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_ace_rearm">
+            <English>ACE Rearm</English>
+            <Chinesesimp>ACE 重新装备</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_ace_rearm_tooltip">
+            <English>Set as ACE Rearm vehicle</English>
+            <Chinesesimp>设置为 ACE 重新装备载具</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_medical">
+            <English>Medical</English>
+            <Chinesesimp>医疗</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_medical_tooltip">
+            <English>Add Medical supplies</English>
+            <Chinesesimp>添加医疗物资</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_airdrop_height">
+            <English>Airdrop height [m]</English>
+            <Chinesesimp>空投高度[米]</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_flyfrom">
+            <English>Fly From</English>
+            <Chinesesimp>起飞地点</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_N">
+            <English>N</English>
+            <Chinesesimp>N - 北</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_NE">
+            <English>NE</English>
+            <Chinesesimp>NE - 东北</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_E">
+            <English>E</English>
+            <Chinesesimp>E - 东</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_SE">
+            <English>SE</English>
+            <Chinesesimp>SE - 东南</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_S">
+            <English>S</English>
+            <Chinesesimp>S - 南</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_SW">
+            <English>SW</English>
+            <Chinesesimp>SW - 西南</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_W">
+            <English>W</English>
+            <Chinesesimp>W - 西</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_NW">
+            <English>NW</English>
+            <Chinesesimp>NW - 西北</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_custom_type">
+            <English>Custom Type (Optional)</English>
+            <Chinesesimp>自定义类型 (可选)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_custom_type_tooltip">
+            <English>Provide classname to aircraft you want to use, instead of using dropdown list</English>
+            <Chinesesimp>为要使用的飞机提供类名，而不是使用下拉列表</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_choose_aircraft">
+            <English>Choose Aircraft</English>
+            <Chinesesimp>选择飞机</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_choose_aircraft_tooltip">
+            <English>What aircraft to drop the supply from</English>
+            <Chinesesimp>选择哪架飞机投放补给</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_aircraft">
+            <English>Aircraft</English>
+            <Chinesesimp>飞机</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_aircraft_tooltip">
+            <English>Make aircraft drop it</English>
+            <Chinesesimp>让飞机空投</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_airdrop">
+            <English>Airdrop</English>
+            <Chinesesimp>空投</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_airdrop_tooltip">
+            <English>Make it airdrop from 300m</English>
+            <Chinesesimp>让它从 300 米处空投</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_multiplier_dialog">
+            <English>Multiplier (amount per player)</English>
+            <Chinesesimp>倍增器（每位玩家的数量）</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_restore_trees_dialog">
+            <English>Restore Trees and bushes in radius</English>
+            <Chinesesimp>恢复地形对象菜单</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_restore_trees_radius">
+            <English>Radius</English>
+            <Chinesesimp>半径</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_restore_trees_trees">
+            <English>Trees</English>
+            <Chinesesimp>树木</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_restore_trees_trees_tooltip">
+            <English>Enable restoration of trees</English>
+            <Chinesesimp>可以恢复的树木</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_restore_trees_bushes">
+            <English>Bushes</English>
+            <Chinesesimp>灌木丛</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_restore_trees_bushes_tooltip">
+            <English>Enable restoration of bushes</English>
+            <Chinesesimp>可以恢复的灌木丛</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_restore_trees_stones">
+            <English>Stones</English>
+            <Chinesesimp>石头</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_restore_trees_stones_tooltip">
+            <English>Enable restoration of stones</English>
+            <Chinesesimp>可以恢复的石头</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_trees_dialog">
+            <English>Remove terrain objects selected in radius</English>
+            <Chinesesimp>删除地形对象菜单</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_trees_stones_tooltip">
+            <English>Enable removal of stones</English>
+            <Chinesesimp>可以移除的石头</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_trees_bushes_tooltip">
+            <English>Enable removal of bushes</English>
+            <Chinesesimp>可以移除的灌木丛</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_trees_trees_tooltip">
+            <English>Enable removal of trees</English>
+            <Chinesesimp>可以移除的树木</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_radio_bino_error">
+            <English>Zeus has removed your radio and/or binoculars</English>
+            <Chinesesimp>宙斯已移除您的无线电 和/或 望远镜</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_radio_bino">
+            <English>Remove Equipment</English>
+            <Chinesesimp>移除设备</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_radio_bino_remove_bino">
+            <English>Remove Binoculars</English>
+            <Chinesesimp>移除望远镜</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_radio_bino_remove_bino_tooltip">
+            <English>Removes binoculars from units binocular slot</English>
+            <Chinesesimp>从设备的望远镜插槽中移除望远镜</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_radio_bino_remove_radio">
+            <English>Remove Radio</English>
+            <Chinesesimp>移除无线电</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_radio_bino_remove_radio_tooltip">
+            <English>Removes radios from units radio slot</English>
+            <Chinesesimp>从设备的无线电插槽中移除无线电</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_radio_bino_group">
+            <English>Entire Group</English>
+            <Chinesesimp>整个小组</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_radio_bino_group_tooltip">
+            <English>Applies to entire group, or only unit selected</English>
+            <Chinesesimp>适用于整个组，或仅适用于所选单位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_remove_radio_bino_side">
+            <English>Side</English>
+            <Chinesesimp>侧面</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_radius_to_heal">
+            <English>Radius to heal</English>
+            <Chinesesimp>治疗半径</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_loadout">
+            <English>Loadout</English>
+            <Chinesesimp>装备配置</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_SL">
+            <English>SL</English>
+            <Chinesesimp>小队长</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_weight">
+            <English>Weight</English>
+            <Chinesesimp>重量</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_dialog">
+            <English>Select Firesupport Type and Area</English>
+            <Chinesesimp>选择火力支援的类型和区域菜单</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_type">
+            <English>Type</English>
+            <Chinesesimp>类型</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_custom_type">
+            <English>Custom Type (ex.)</English>
+            <Chinesesimp>自定义类型 (例.)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_seconds_salvo">
+            <English>Seconds between Salvos</English>
+            <Chinesesimp>每发之间的间隔时间</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_start_after">
+            <English>Start after ... seconds</English>
+            <Chinesesimp>... 秒后启动</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_stop_after">
+            <English>Stop After Salvos (0 = indef.)</English>
+            <Chinesesimp>在射击齐发后停止 (0 = 无限)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_guns">
+            <English>Guns</English>
+            <Chinesesimp>枪支</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_display_radius">
+            <English>Display Radius (only &lt;=200m)</English>
+            <Chinesesimp>显示半径 (仅 &lt;=200m)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_mortar">
+            <English>82 mm Mortar</English>
+            <Chinesesimp>82 mm 迫击炮</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_howitzer">
+            <English>155 mm Howitzer</English>
+            <Chinesesimp>155 mm 榴弹炮</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_rocket">
+            <English>230 mm Rocket</English>
+            <Chinesesimp>230 mm 火箭弹</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_flare_white">
+            <English>Flare 40mm White</English>
+            <Chinesesimp>40mm 白色照明弹</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_fire_support_smoke_white">
+            <English>Smoke 120mm White</English>
+            <Chinesesimp>120 毫米白色烟雾弹</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_delete_dead">
+            <English>Are you sure you want to delete ALL dead?</English>
+            <Chinesesimp>您确定要删除所有的死亡尸体吗?</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_delete_bodies">
+            <English>Delete Bodies</English>
+            <Chinesesimp>删除尸体</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_delete_bodies_tooltip">
+            <English>Deletes all dead bodies not inside vehicles</English>
+            <Chinesesimp>删除所有不在车辆内的尸体</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_delete_wrecks">
+            <English>Delete Wrecks</English>
+            <Chinesesimp>删除残骸</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_delete_wrecks_tooltip">
+            <English>Deletes all wrecks and any crew inside</English>
+            <Chinesesimp>删除所有残骸和车内的尸体</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_delete_animal_followers">
+            <English>Are you sure you will delete all animals following people?</English>
+            <Chinesesimp>你确定要删除跟随的所有动物吗?</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_ignore_players">
+            <English>Ignore players</English>
+            <Chinesesimp>忽略玩家</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_removed">
+            <English>removed</English>
+            <Chinesesimp>移除</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_replaced">
+            <English>replaced</English>
+            <Chinesesimp>替换</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_zeus_has_removed">
+            <English>Zeus has %1 your %2</English>
+            <Chinesesimp>Zeus 已经 %1 你的 %2</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_whole_group">
+            <English>Whole Group</English>
+            <Chinesesimp>整个小组</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_whole_group_tooltip">
+            <English>Remove items from this unit's group</English>
+            <Chinesesimp>从此单位的小组中移除物品</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_item_type">
+            <English>Item Type</English>
+            <Chinesesimp>物品种类</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_item_type_tooltip">
+            <English>"Signals" includes smoke grenades, chemlights, IR strobes, and UGL smokes.&lt;br/&gt;"UGL" includes explosive ammo for under-barrel and dedicated grenade launchers</English>
+            <Chinesesimp>"信号"包括烟雾弹,化学灯,红外闪光灯和UGL烟雾.&lt;br/&gt;"UGL"包括用于下挂和专用榴弹发射器的爆炸弹药</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_signals">
+            <English>Signals</English>
+            <Chinesesimp>信号</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_grenades">
+            <English>Grenades</English>
+            <Chinesesimp>手榴弹</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_explosives">
+            <English>Explosives</English>
+            <Chinesesimp>爆炸物</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_ugl">
+            <English>UGL</English>
+            <Chinesesimp>UGL(下挂榴弹发射器)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_launchers">
+            <English>Launchers</English>
+            <Chinesesimp>发射器</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_replace_with">
+            <English>Replace with</English>
+            <Chinesesimp>替换为</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_replace_with_custom">
+            <English>Replace with (custom)</English>
+            <Chinesesimp>替换为(自定义)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_replace_with_custom_tooltip">
+            <English>A custom magazine or item to replace with&lt;br/&gt;(Must be in "CfgMagazines" or inherit from "ItemCore")</English>
+            <Chinesesimp>用于替换的自定义弹匣或物品&lt;br/&gt;(必须在 "CfgMagazines" 中或继承自 "ItemCore")</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_leave_untouched">
+            <English>Leave untouched</English>
+            <Chinesesimp>保持不变</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_leave_untouched_tooltip">
+            <English>Amount of unit's inventory to leave unchanged.&lt;br/&gt;Does not guarantee which type is preserved if the unit has, e.g. multiple colours of smoke.</English>
+            <Chinesesimp>保持单位库存不变的数量.&lt;br/&gt;如果单位有多种类型的物品,如不同颜色的烟雾,不能保证保留哪种类型</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_strip_explosives_dialog">
+            <English>Remove Explosives</English>
+            <Chinesesimp>移除爆炸物</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke">
+            <English>Suitcase Device</English>
+            <Chinesesimp>手提箱设备</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_edit">
+            <English>Edit Suitcase Device</English>
+            <Chinesesimp>编辑手提箱设备</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_error_zeusPlacement">
+            <English>Must be place on an existing Device, or nothing</English>
+            <Chinesesimp>必须放置在现有设备上, 或者不放置任何东西</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuse">
+            <English>Defuse Device</English>
+            <Chinesesimp>解除设备</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_none">
+            <English>Nothing</English>
+            <Chinesesimp>无</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_explosion_small">
+            <English>Explosion (Small)</English>
+            <Chinesesimp>爆炸 (小型)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_explosion_large">
+            <English>Explosion (Large)</English>
+            <Chinesesimp>爆炸 (大型)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_explosion_nuclear">
+            <English>Explosion (Nuclear)</English>
+            <Chinesesimp>爆炸 (核)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_smoke_red">
+            <English>Smoke (Red)</English>
+            <Chinesesimp>烟雾 (红色)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_smoke_yellow">
+            <English>Smoke (Yellow)</English>
+            <Chinesesimp>烟雾 (黄色)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_emp">
+            <English>EMP</English>
+            <Chinesesimp>电磁脉冲</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_timer">
+            <English>Timer</English>
+            <Chinesesimp>定时器</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_timer_tooltip">
+            <English>How long until the device activates in MM:SS</English>
+            <Chinesesimp>设备启动前还有多少时间，格式为分:秒</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect">
+            <English>Effect</English>
+            <Chinesesimp>效果</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_effect_tooltip">
+            <English>What happens when the device activates</English>
+            <Chinesesimp>当设备启动时会发生什么</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable">
+            <English>Defusable</English>
+            <Chinesesimp>可解除的</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable_tooltip">
+            <English>Who can attempt to defuse the device</English>
+            <Chinesesimp>谁可以尝试解除设备</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable_noone">
+            <English>No-one</English>
+            <Chinesesimp>无人</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable_specialist">
+            <English>Explosive Specialists</English>
+            <Chinesesimp>爆炸专家</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable_engineer">
+            <English>Engineers</English>
+            <Chinesesimp>工程师</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defuseable_any">
+            <English>Anyone</English>
+            <Chinesesimp>任何人</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defusetimer">
+            <English>Defuse Time</English>
+            <Chinesesimp>解除时间</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_defusetimer_tooltip">
+            <English>How long does it take to defuse the device in MM:SS</English>
+            <Chinesesimp>需要多少时间来解除设备(以分:秒为单位)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_armed">
+            <English>Armed</English>
+            <Chinesesimp>已装填/已激活</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_suitcaseNuke_armed_tooltip">
+            <English>Whether the device can be detonated&lt;br/&gt;If not armed, countdown is paused</English>
+            <Chinesesimp>设备是否可以被引爆&lt;br/&gt; 如果未装填/未激活, 倒计时暂停</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_follow_animal">
+            <English>Select Animal Type</English>
+            <Chinesesimp>动物生成菜单</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal">
+            <English>Animal</English>
+            <Chinesesimp>动物</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_dog">
+            <English>Dog</English>
+            <Chinesesimp>狗</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_sheep">
+            <English>Sheep</English>
+            <Chinesesimp>绵羊</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_goat">
+            <English>Goat</English>
+            <Chinesesimp>山羊</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_rabbit">
+            <English>Rabbit</English>
+            <Chinesesimp>兔子</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_hen">
+            <English>Hen</English>
+            <Chinesesimp>母鸡</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_snake">
+            <English>Snake</English>
+            <Chinesesimp>蛇</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_amount">
+            <English>Amount</English>
+            <Chinesesimp>数量</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_spawn_offset">
+            <English>Spawn offset [m]</English>
+            <Chinesesimp>生成偏移 [m]</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_spawn_offset_tooltip">
+            <English>How far away in random direction the animals should spawn</English>
+            <Chinesesimp>动物随机生成的方向距离</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_scale">
+            <English>Scale*</English>
+            <Chinesesimp>大小*</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_scale_tooltip">
+            <English>Experimental feature that doesn't always work. Works best on snakes</English>
+            <Chinesesimp>试验性功能'并非总是有效. 在蛇身上效果最佳</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_invincible">
+            <English>Set Invincible</English>
+            <Chinesesimp>设置无敌</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_attack_nearby">
+            <English>Attack Nearby Units</English>
+            <Chinesesimp>攻击附近单位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_pet_animal">
+            <English>Pet</English>
+            <Chinesesimp>宠物</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_sound_dog">
+            <English>WOOF</English>
+            <Chinesesimp>汪汪 (狗叫声)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_sound_sheep">
+            <English>MÆÆÆÆÆHH</English>
+            <Chinesesimp>呜呜呜 (动物的哀鸣声)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_sound_goat">
+            <English>MAAAAA..Mariner..AAAA</English>
+            <Chinesesimp>呜呜...航海者...呜呜 (模仿海鸥叫声或海员的呼唤声)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_sound_rabbit">
+            <English>PUUUUUUURRRRR</English>
+            <Chinesesimp>纯粹 (猫叫声)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_sound_hen">
+            <English>CLUCK-CLUCK</English>
+            <Chinesesimp>咯咯 (鸡叫声)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_animal_sound_snake">
+            <English>HISSSSS, No Step On Snek!</English>
+            <Chinesesimp>嘶嘶嘶, 不要踩到蛇!</Chinesesimp>
+        </Key>
+    </Package>
 </Project>
-
-

--- a/addons/pingbox/stringtable.xml
+++ b/addons/pingbox/stringtable.xml
@@ -1,29 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="Crows Zeus Additions">
-      <Package name="pingbox">
-            <Key ID="STR_CROWSZA_Pingbox_setting_enable">
-                  <English>Enable PingBox</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Pingbox_setting_enable_tooltip">
-                  <English>Pingbox sits in lower left corner and shows the last 3 zeus pings and how long since it was pinged</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Pingbox_setting_threshold">
-                  <English>Remove Threshold</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Pingbox_setting_threshold_tooltip">
-                  <English>Time before a ping will automatically be removed from the PingBox</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Pingbox_setting_fading">
-                  <English>Enable Fading</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Pingbox_setting_fading_tooltip">
-                  <English>PingBox will fade from view after set duration, and reappear when a new ping is received</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Pingbox_setting_fade_duration">
-                  <English>Duration Before Fade</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Pingbox_setting_fade_duration_tooltip">
-                  <English>Time before the PingBox will fade from view if Fading is enabled</English>
-            </Key>
-      </Package>
+    <Package name="pingbox">
+        <Key ID="STR_CROWSZA_Pingbox_setting_enable">
+            <English>Enable PingBox</English>
+            <Chinesesimp>启用 PingBox</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Pingbox_setting_enable_tooltip">
+            <English>Pingbox sits in lower left corner and shows the last 3 zeus pings and how long since it was pinged</English>
+            <Chinesesimp>Pingbox 位于左下角 , 显示最近 3 次 Zeus ping 的时间以及被 ping 的时间</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Pingbox_setting_threshold">
+            <English>Remove Threshold</English>
+            <Chinesesimp>移除时间</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Pingbox_setting_threshold_tooltip">
+            <English>Time before a ping will automatically be removed from the PingBox</English>
+            <Chinesesimp>Ping 从 PingBox 自动移除前的时间</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Pingbox_setting_fading">
+            <English>Enable Fading</English>
+            <Chinesesimp>启用淡出</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Pingbox_setting_fading_tooltip">
+            <English>PingBox will fade from view after set duration, and reappear when a new ping is received</English>
+            <Chinesesimp>PingBox 将在设定的持续时间后从视图中淡出 , 并在收到新的 ping 时重新出现</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Pingbox_setting_fade_duration">
+                <English>Duration Before Fade</English>
+                <Chinesesimp>渐变前持续时间</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Pingbox_setting_fade_duration_tooltip">
+            <English>Time before the PingBox will fade from view if Fading is enabled</English>
+            <Chinesesimp>如果启用渐变 , PingBox 从视图中淡出前的时间</Chinesesimp>
+        </Key>
+    </Package>
 </Project>

--- a/addons/teleport/stringtable.xml
+++ b/addons/teleport/stringtable.xml
@@ -1,95 +1,125 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="Crows Zeus Additions">
-      <Package name="teleport">
-            <Key ID="STR_CROWSZA_Teleport_scatter_teleport">
-                  <English>Scatter Teleport</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_teleport_to_squadmate">
-                  <English>Teleport To Squadmember</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_set_teleport_to_squadmate">
-                  <English>Set Teleport to Squadmember</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_select_member_to_teleport_to">
-                  <English>Select SquadMember to teleport to</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_squadleader">
-                  <English>SquadLeader</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_in_vehicle">
-                  <English>[In Vehicle]</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_squad_members">
-                  <English>Squad Members</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_action_teleport_to_squadmate">
-                  <English>&lt;t color="#FFFF00"&gt;Teleport To Squadmate</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_action_error">
-                  <English>You must select an object</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter">
-                  <English>Scatter Teleport Players</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_units_to_tp">
-                  <English>Units to TP</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_distance_between">
-                  <English>Distance Between Players [m]</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_altitude">
-                  <English>Altitude Above Ground [m]</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_include_vehicle">
-                  <English>Include Vehicles</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_include_vehicle_tooltip">
-                  <English>Teleports vehicles if selected player is crew</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_pattern">
-                  <English>TP Pattern</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_pattern_tooltip">
-                  <English>What pattern the units should be teleported as</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_pattern_spiral">
-                  <English>Outward Spiral</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_pattern_line">
-                  <English>Line</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_pattern_p">
-                  <English>P Pattern</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_direction">
-                  <English>Direction (If LinePattern)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_direction_tooltip">
-                  <English>The direction the line grows</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_n">
-                  <English>North</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_ne">
-                  <English>North East</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_nw">
-                  <English>North West</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_e">
-                  <English>East</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_s">
-                  <English>South</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_se">
-                  <English>South East</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_sw">
-                  <English>South West</English>
-            </Key>
-            <Key ID="STR_CROWSZA_Teleport_scatter_w">
-                  <English>West</English>
-            </Key>
-      </Package>
+    <Package name="teleport">
+        <Key ID="STR_CROWSZA_Teleport_scatter_teleport">
+            <English>Scatter Teleport</English>
+            <Chinesesimp>传送 - 分散传送</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_teleport_to_squadmate">
+            <English>Teleport To Squadmember</English>
+            <Chinesesimp>传送 - 传送至小队成员</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_set_teleport_to_squadmate">
+            <English>Set Teleport to Squadmember</English>
+            <Chinesesimp>传送 - 将远程传送设置为小队成员</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_select_member_to_teleport_to">
+            <English>Select SquadMember to teleport to</English>
+            <Chinesesimp>选择要传送到的小队成员</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_squadleader">
+            <English>SquadLeader</English>
+            <Chinesesimp>小队长</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_in_vehicle">
+            <English>[In Vehicle]</English>
+            <Chinesesimp>[在载具中]</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_squad_members">
+            <English>Squad Members</English>
+            <Chinesesimp>小队成员</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_action_teleport_to_squadmate">
+            <English>&lt;t color="#FFFF00"&gt;Teleport To Squadmate</English>
+            <Chinesesimp>&lt;t color="#FFFF00"&gt;传送到小队成员</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_action_error">
+            <English>You must select an object</English>
+            <Chinesesimp>你必须选择一个对象</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter">
+            <English>Scatter Teleport Players</English>
+            <Chinesesimp>散射传送玩家</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_units_to_tp">
+            <English>Units to TP</English>
+            <Chinesesimp>要传送的单位</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_distance_between">
+            <English>Distance Between Players [m]</English>
+            <Chinesesimp>玩家之间的距离 [米]</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_altitude">
+            <English>Altitude Above Ground [m]</English>
+            <Chinesesimp>距离地面的高度 [米]</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_include_vehicle">
+            <English>Include Vehicles</English>
+            <Chinesesimp>包括载具</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_include_vehicle_tooltip">
+            <English>Teleports vehicles if selected player is crew</English>
+            <Chinesesimp>如果选定的玩家是载具成员，则传送载具</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_pattern">
+            <English>TP Pattern</English>
+            <Chinesesimp>传送模式</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_pattern_tooltip">
+            <English>What pattern the units should be teleported as</English>
+            <Chinesesimp>单位应以何种模式进行传送</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_pattern_spiral">
+            <English>Outward Spiral</English>
+            <Chinesesimp>向外螺旋</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_pattern_line">
+            <English>Line</English>
+            <Chinesesimp>直线模式</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_pattern_p">
+            <English>P Pattern</English>
+            <Chinesesimp>P字型模式</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_direction">
+            <English>Direction (If LinePattern)</English>
+            <Chinesesimp>方向(如果使用直线模式)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_direction_tooltip">
+            <English>The direction the line grows</English>
+            <Chinesesimp>线条增长的方向</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_n">
+            <English>North</English>
+            <Chinesesimp>北</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_ne">
+            <English>North East</English>
+            <Chinesesimp>东北</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_nw">
+            <English>North West</English>
+            <Chinesesimp>西北</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_e">
+            <English>East</English>
+            <Chinesesimp>东</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_s">
+            <English>South</English>
+            <Chinesesimp>南</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_se">
+            <English>South East</English>
+            <Chinesesimp>东南</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_sw">
+            <English>South West</English>
+            <Chinesesimp>西南</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_Teleport_scatter_w">
+            <English>West</English>
+            <Chinesesimp>西</Chinesesimp>
+        </Key>
+    </Package>
 </Project>

--- a/addons/tfar/stringtable.xml
+++ b/addons/tfar/stringtable.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="Crows Zeus Additions">
-      <Package name="tfar">
-            <Key ID="STR_CROWSZA_tfar_radio_side">
-                  <English>Set TFAR Vehicle Radio Side</English>
-            </Key>
-            <Key ID="STR_CROWSZA_tfar_side">
-                  <English>TFAR Vehicle Side</English>
-            </Key>
-            <Key ID="STR_CROWSZA_tfar_error">
-                  <English>Selected unit is not a vehicle</English>
-            </Key>
-      </Package>
+    <Package name="tfar">
+        <Key ID="STR_CROWSZA_tfar_radio_side">
+            <English>Set TFAR Vehicle Radio Side</English>
+            <Chinesesimp>设置 TFAR 车辆无线电</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_tfar_side">
+            <English>TFAR Vehicle Side</English>
+            <Chinesesimp>TFAR 载具 Side</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_tfar_error">
+            <English>Selected unit is not a vehicle</English>
+            <Chinesesimp>选定的单位不是载具</Chinesesimp>
+        </Key>
+    </Package>
 </Project>

--- a/addons/zeus_text/stringtable.xml
+++ b/addons/zeus_text/stringtable.xml
@@ -1,89 +1,117 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="Crows Zeus Additions">
-      <Package name="zeus_text">
-            <Key ID="STR_CROWSZA_zeustext_setting_medical_overlay">
-                  <English>Show medical overlay</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_setting_medical_overlay_tooltip">
-                  <English>Shows medical info for players in zeus view for units. (medical status)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_num_wounds">
-                  <English>Show No. of wounds and HR.</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_num_wounds_tooltip">
-                  <English>Show line with number of wounds and heart rate.</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_medical_hud">
-                  <English>Medical HUD (default:  Ctrl + Shift + H)</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_show_pain">
-                  <English>Show pain and bleeding rate</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_show_pain_tooltip">
-                  <English>Show if player is in pain and bleeding rate</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_show_medications">
-                  <English>Show medications</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_show_medications_tooltip">
-                  <English>Show what medications is effecting the player</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_show_rc_icon">
-                  <English>Show RC Icon</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_show_rc_icon_tooltip">
-                  <English>Shows an zeus icon over units currently being RC'ed by any zeus</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_icon_colour">
-                  <English>Icon Colour</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_icon_colour_tooltip">
-                  <English>What colour the icon is shown with</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_surrender_icon">
-                  <English>Show Surrender Icon</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_surrender_icon_tooltip">
-                  <English>Shows an icon over units with a chance to surrender</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_surrender_chance">
-                  <English>Surrender Chance</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_surrender_icon_colour">
-                  <English>Icon Colour</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_surrender_icon_colour_tooltip">
-                  <English>What colour the icon is shown with</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_onkilled_icon">
-                  <English>Show "Activate On Death" Icon</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_onkilled_icon_tooltip">
-                  <English>Shows an icon over units with custom "Activate On Death" actions applied by zeus</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_onkilled_icon_colour">
-                  <English>Icon Colour</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_onkilled_icon_colour_tooltip">
-                  <English>What colour the icon is shown with</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_onkilled">
-                  <English>Activate On Death</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_wounds">
-                  <English>Wounds</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_hr">
-                  <English>HR</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_in_pain">
-                  <English>In Pain, Bleed Rate</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_bleed_rate">
-                  <English>Bleed Rate:%2, In Cardiac Arrest!</English>
-            </Key>
-            <Key ID="STR_CROWSZA_zeustext_effected_by">
-                  <English>Effected by</English>
-            </Key>
-      </Package>
+    <Package name="zeus_text">
+        <Key ID="STR_CROWSZA_zeustext_setting_medical_overlay">
+            <English>Show medical overlay</English>
+            <Chinesesimp>显示医疗覆盖图</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_setting_medical_overlay_tooltip">
+            <English>Shows medical info for players in zeus view for units. (medical status)</English>
+            <Chinesesimp>在宙斯视图中显示单位玩家的医疗信息. (医疗状态)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_num_wounds">
+            <English>Show No. of wounds and HR.</English>
+            <Chinesesimp>显示伤口数量和心率.</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_num_wounds_tooltip">
+            <English>Show line with number of wounds and heart rate.</English>
+            <Chinesesimp>显示伤口数量和心率的线条.</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_medical_hud">
+            <English>Medical HUD (default:  Ctrl + Shift + H)</English>
+            <Chinesesimp>医疗 HUD (默认:Ctrl + Shift + H)</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_show_pain">
+            <English>Show pain and bleeding rate</English>
+            <Chinesesimp>显示疼痛和出血率</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_show_pain_tooltip">
+            <English>Show if player is in pain and bleeding rate</English>
+            <Chinesesimp>显示玩家是否疼痛和出血率</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_show_medications">
+            <English>Show medications</English>
+            <Chinesesimp>显示药物</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_show_medications_tooltip">
+            <English>Show what medications is effecting the player</English>
+            <Chinesesimp>显示哪些药物对玩家有影响</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_show_rc_icon">
+            <English>Show RC Icon</English>
+            <Chinesesimp>显示 RC 图标</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_show_rc_icon_tooltip">
+            <English>Shows an zeus icon over units currently being RC'ed by any zeus</English>
+            <Chinesesimp>在当前被任何宙斯 RC 的单位上显示一个宙斯图标</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_icon_colour">
+            <English>Icon Colour</English>
+            <Chinesesimp>图标颜色</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_icon_colour_tooltip">
+            <English>What colour the icon is shown with</English>
+            <Chinesesimp>图标显示的颜色</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_surrender_icon">
+            <English>Show Surrender Icon</English>
+            <Chinesesimp>显示投降图标</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_surrender_icon_tooltip">
+            <English>Shows an icon over units with a chance to surrender</English>
+            <Chinesesimp>在有机会投降的单位上显示一个图标</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_surrender_chance">
+            <English>Surrender Chance</English>
+            <Chinesesimp>投降的机会</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_surrender_icon_colour">
+            <English>Icon Colour</English>
+            <Chinesesimp>图标颜色</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_surrender_icon_colour_tooltip">
+            <English>What colour the icon is shown with</English>
+            <Chinesesimp>图标显示的颜色</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_onkilled_icon">
+            <English>Show "Activate On Death" Icon</English>
+            <Chinesesimp>显示"死亡激活"图标</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_onkilled_icon_tooltip">
+            <English>Shows an icon over units with custom "Activate On Death" actions applied by zeus</English>
+            <Chinesesimp>在由Zeus应用了自定义"死亡激活"动作的单位上显示图标</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_onkilled_icon_colour">
+            <English>Icon Colour</English>
+            <Chinesesimp>图标颜色</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_onkilled_icon_colour_tooltip">
+            <English>What colour the icon is shown with</English>
+            <Chinesesimp>图标显示的颜色</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_onkilled">
+            <English>Activate On Death</English>
+            <Chinesesimp>死亡激活</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_wounds">
+            <English>Wounds</English>
+            <Chinesesimp>伤势</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_hr">
+            <English>HR</English>
+            <Chinesesimp>心率</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_in_pain">
+            <English>In Pain, Bleed Rate</English>
+            <Chinesesimp>疼痛,出血率</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_bleed_rate">
+            <English>Bleed Rate:%2, In Cardiac Arrest!</English>
+            <Chinesesimp>出血率:2%,心脏骤停!</Chinesesimp>
+        </Key>
+        <Key ID="STR_CROWSZA_zeustext_effected_by">
+            <English>Effected by</English>
+            <Chinesesimp>受...影响</Chinesesimp>
+        </Key>
+    </Package>
 </Project>


### PR DESCRIPTION
A simplified Chinese translation has been incorporated into the Stringtable.xml file,
which includes
addons/ace/stringtable.xml,
addons/drawbuild/stringtable.xml, 
addons/misc/stringtable.xml,
addons/pingbox/stringtable.xml,
addons/teleport/stringtable.xml,
addons/tfar/stringtable.xml，
and addons/zeus_text/stringtable.xml.

"The Projectile Type in line 94 of the fnc_aceDamageToUnit.sqf file within the functions folder of the ACE folder has not been set in the stringtable.xml"
