### PR TITLE
added option to include zeus loadout in resupply module

### DIFF
--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -4,7 +4,7 @@ workshop = [
     "450814997",  # CBA_A3's Workshop ID
     "894678801",  # TFAR Beta
     "1779063631", # Zeus Enhanced 
-    "2369477168", # Advanced Developer Tools
+    "3499977893", # Advanced Developer Tools
     "463939057",  # ACE
     #"1645973522", # Intercept Minimal Dev
     #"1585582292", # Arma Debug Engine

--- a/addons/misc/functions/fnc_resupplyPlayerLoadouts.sqf
+++ b/addons/misc/functions/fnc_resupplyPlayerLoadouts.sqf
@@ -26,6 +26,7 @@ private _onConfirm =
 		"_flyfrom",
 		"_height",
 		"_medical",
+		"_includeZeus",
 		"_rearm"
 	];
 	//Get in params again
@@ -41,7 +42,7 @@ private _onConfirm =
 	// run though all players
 	{
 		// if zeus, skip it
-		if (!isNull (getAssignedCuratorLogic _x)) then { continue; };
+		if (!isNull (getAssignedCuratorLogic _x) && !_includeZeus) then { continue; };
 
 		// get all magazines from players
 		private _mags = magazines [_x, true];
@@ -240,7 +241,8 @@ private _dialogOptions = [EGVAR(main,aceLoaded), GVAR(resupply_aircraftList), GV
 		["EDIT",[localize "STR_CROWSZA_Misc_resupply_loadouts_custom_type", localize "STR_CROWSZA_Misc_resupply_loadouts_custom_type_tooltip"], "", false],
 		["TOOLBOX", localize "STR_CROWSZA_Misc_resupply_loadouts_flyfrom", [0, 1, 8, [localize "STR_CROWSZA_Misc_N", localize "STR_CROWSZA_Misc_NE", localize "STR_CROWSZA_Misc_E", localize "STR_CROWSZA_Misc_SE", localize "STR_CROWSZA_Misc_S", localize "STR_CROWSZA_Misc_SW", localize "STR_CROWSZA_Misc_W", localize "STR_CROWSZA_Misc_NW"]]],
 		["SLIDER",localize "STR_CROWSZA_Misc_resupply_loadouts_airdrop_height",[50,1000,200,0]],
-		["CHECKBOX",[localize "STR_CROWSZA_Misc_resupply_loadouts_medical", localize "STR_CROWSZA_Misc_resupply_loadouts_medical_tooltip"],[true]]
+		["CHECKBOX",[localize "STR_CROWSZA_Misc_resupply_loadouts_medical", localize "STR_CROWSZA_Misc_resupply_loadouts_medical_tooltip"],[true]],
+		["CHECKBOX",[localize "STR_CROWSZA_Misc_resupply_loadouts_zeus", localize "STR_CROWSZA_Misc_resupply_loadouts_zeus_tooltip"],[false]]
 	];
 
 	// add options for ace rearm vehicle if ace is used

--- a/addons/misc/stringtable.xml
+++ b/addons/misc/stringtable.xml
@@ -541,6 +541,16 @@
             <Chinesesimp>添加医疗物资</Chinesesimp>
             <French>Ajouter du matériel médical</French>
         </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_zeus">
+            <English>Include Zeus</English>
+            <Chinesesimp>包括宙斯</Chinesesimp>
+            <French>Inclure Zeus</French>
+        </Key>
+        <Key ID="STR_CROWSZA_Misc_resupply_loadouts_zeus_tooltip">
+            <English>Include Zeus' loadout to resupply</English>
+            <Chinesesimp>包括宙斯的装备以进行补给</Chinesesimp>
+            <French>Ajouter l'équipement du Zeus dans le réapprovisionnement</French>
+        </Key>
         <Key ID="STR_CROWSZA_Misc_resupply_loadouts_airdrop_height">
             <English>Airdrop height [m]</English>
             <Chinesesimp>空投高度[米]</Chinesesimp>


### PR DESCRIPTION
Adds requested feature to allow zeus to include the zeus loadout in resupply module. So instances where zeus is playing with players, they still get their resupply items. 