### PR TITLE
[Pingbox] Prevent older pings from being buried by spam-pinging

### DIFF
--- a/addons/pingbox/XEH_preInit.sqf
+++ b/addons/pingbox/XEH_preInit.sqf
@@ -30,6 +30,15 @@ GVAR(hidden) = false;
 	[1, 900, 600, 0] // data for this setting: [min, max, default, number of shown trailing decimals]
 ] call CBA_fnc_addSetting;
 
+// TIME window where pings would be grouped together into one spam ping
+[
+	QGVAR(CBA_Setting_spamPing_threshold),
+	"SLIDER",
+	[localize "STR_CROWSZA_Pingbox_setting_spamPing_threshold", localize "STR_CROWSZA_Pingbox_setting_spamPing_threshold_tooltip"],
+	["Crows Zeus Additions", "PingBox"],
+	[0, 120, 60, 0] // data for this setting: [min, max, default, number of shown trailing decimals]
+] call CBA_fnc_addSetting;
+
 // FADE OUT for pingbox
 [
 	QGVAR(CBA_Setting_fade_enabled),

--- a/addons/pingbox/functions/fnc_addEntryPingBoxHUD.sqf
+++ b/addons/pingbox/functions/fnc_addEntryPingBoxHUD.sqf
@@ -26,7 +26,7 @@ if (_index > -1) then {
 	private _previousPing = GVAR(ping_list) select _index;
 	_previousPing params ["_name", "_previousPingTime", "_previousNumPings"];
 	
-	// If the last ping was less than a minute ago, we count it as ping-spamming
+	// If the last ping was less than a spamPing_threshold seconds ago, we count it as ping-spamming
 	private _timeDiff = round(time - _previousPingTime);
 	if (_timeDiff < GVAR(CBA_Setting_spamPing_threshold)) then {
 		_numPings = _previousNumPings + 1;

--- a/addons/pingbox/functions/fnc_addEntryPingBoxHUD.sqf
+++ b/addons/pingbox/functions/fnc_addEntryPingBoxHUD.sqf
@@ -28,7 +28,7 @@ if (_index > -1) then {
 	
 	// If the last ping was less than a minute ago, we count it as ping-spamming
 	private _timeDiff = round(time - _previousPingTime);
-	if (_timeDiff < 60) then {
+	if (_timeDiff < GVAR(CBA_Setting_spamPing_threshold)) then {
 		_numPings = _previousNumPings + 1;
 	};
 	

--- a/addons/pingbox/functions/fnc_addEntryPingBoxHUD.sqf
+++ b/addons/pingbox/functions/fnc_addEntryPingBoxHUD.sqf
@@ -14,12 +14,24 @@ Enables and displays the pingbox hud
 params ["_player"];
 
 // ARRAY is made so newest entries are first, and oldest pushed at the back
-// [[_playername, timeAtPing], ...]
+// [[_playername, timeAtPing, numberOfRecentPings], ...]
+
+// How many times the player has pinged recently
+private _numPings = 1;
 
 // Remove existing entry for this player (if any)
 // This prevents older pings from getting "buried" by spam pinging
 private _index = GVAR(ping_list) findIf {(_x select 0) isEqualTo _player};
 if (_index > -1) then {
+	private _previousPing = GVAR(ping_list) select _index;
+	_previousPing params ["_name", "_previousPingTime", "_previousNumPings"];
+	
+	// If the last ping was less than a minute ago, we count it as ping-spamming
+	private _timeDiff = round(time - _previousPingTime);
+	if (_timeDiff < 60) then {
+		_numPings = _previousNumPings + 1;
+	};
+	
     GVAR(ping_list) deleteAt _index;
 };
 
@@ -29,7 +41,7 @@ if (count GVAR(ping_list) >= 3) then {
 };
 
 // pushBack to array 
-GVAR(ping_list) pushBack [_player, time];
+GVAR(ping_list) pushBack [_player, time, _numPings];
 
 // sort array 
 GVAR(ping_list) = [GVAR(ping_list), [], {_x select 1}, "DESC"] call BIS_fnc_sortBy;

--- a/addons/pingbox/functions/fnc_addEntryPingBoxHUD.sqf
+++ b/addons/pingbox/functions/fnc_addEntryPingBoxHUD.sqf
@@ -16,6 +16,13 @@ params ["_player"];
 // ARRAY is made so newest entries are first, and oldest pushed at the back
 // [[_playername, timeAtPing], ...]
 
+// Remove existing entry for this player (if any)
+// This prevents older pings from getting "buried" by spam pinging
+private _index = GVAR(ping_list) findIf {(_x select 0) isEqualTo _player};
+if (_index > -1) then {
+    GVAR(ping_list) deleteAt _index;
+};
+
 // check count of global array with entries, if > 3, pop the oldest in array. (FIFO)
 if (count GVAR(ping_list) >= 3) then {
 	GVAR(ping_list) deleteAt 2;

--- a/addons/pingbox/functions/fnc_refreshPingBoxHUD.sqf
+++ b/addons/pingbox/functions/fnc_refreshPingBoxHUD.sqf
@@ -42,9 +42,13 @@ lnbClear _ctrlList;
 private _delArr = [];
 // add new entry
 {
-	_x params ["_player", "_pingtime"];
+	_x params ["_player", "_pingtime", "_numPings"];
 	private _timeDiff = round(time - _pingtime);
 	private _name = name _player;
+	
+	if (_numPings > 1) then {
+		_name = format ["%1 (%2)", _name, _numPings];
+	};
 
 	// if we are over the set threshold, we should not draw and remove instead
 	if (_timeDiff > GVAR(CBA_Setting_oldLimit)) then {

--- a/addons/pingbox/stringtable.xml
+++ b/addons/pingbox/stringtable.xml
@@ -41,5 +41,15 @@
             <Chinesesimp>如果启用渐变 , PingBox 从视图中淡出前的时间</Chinesesimp>
             <French>Temps avant que la PingBox ne disparaisse de la vue si l'option Fondu est activée</French>
         </Key>
+		<Key ID="STR_CROWSZA_Pingbox_setting_spamPing_threshold">
+			<English>Spam Ping Threshold</English>
+			<Chinesesimp>连续标记阈值</Chinesesimp>
+			<French>Seuil de pings répétés</French>
+		</Key>
+		<Key ID="STR_CROWSZA_Pingbox_setting_spamPing_threshold_tooltip">
+			<English>Time threshold in seconds during which repeated pings from the same player are counted as spam pings. If more time has passed, the ping is considered a completely new one.</English>
+			<Chinesesimp>在此时间阈值内 , 同一玩家的重复标记将被视为连续标记并合并显示。超过该时间后 , 标记将被视为全新的标记。</Chinesesimp>
+			<French>Seuil en secondes pendant lequel plusieurs pings du même joueur sont considérés comme des pings répétés et sont regroupés. Si plus de temps s’est écoulé, le ping est traité comme un tout nouveau.</French>
+		</Key>
     </Package>
 </Project>

--- a/addons/pingbox/stringtable.xml
+++ b/addons/pingbox/stringtable.xml
@@ -50,6 +50,7 @@
 			<English>Time threshold in seconds during which repeated pings from the same player are counted as spam pings. If more time has passed, the ping is considered a completely new one.</English>
 			<Chinesesimp>在此时间阈值内 , 同一玩家的重复标记将被视为连续标记并合并显示。超过该时间后 , 标记将被视为全新的标记。</Chinesesimp>
 			<French>Seuil en secondes pendant lequel plusieurs pings du même joueur sont considérés comme des pings répétés et sont regroupés. Si plus de temps s’est écoulé, le ping est traité comme un tout nouveau.</French>
+		</Key>
 		<Key ID="STR_CROWSZA_Pingbox_setting_size">
 			<English>Pingbox Size</English>
 			<Chinesesimp>Pingbox 大小</Chinesesimp>


### PR DESCRIPTION
**What does it solve?**
Example situation:
1. **Player A** pings the Zeus once and appears in the ping box. The Zeus is busy and can't respond immediately.
2. **Player B** pings the Zeus once and appears in the ping box. The Zeus is busy and can't respond immediately.
3. **Player C** is very impatient (it happens a lot) and needs Zeuses attention immediately. **Player C pings the Zeus 5 times in 2 seconds.**
Result from Zeus' POV: The entire PingBox is spammed with pings from Player C. _Pings from Player A and Player B are no longer visible._

**Solution:**
- Instead of granting Player C unlimited spots in the PingBox, we check if he is already listed in the list of players.
- If so, we remove the older ping, but we still give Player C the top-most place in the list of pings
- Older pings from Player A and Player B are still preserved

Basically it introduces the rule of "One player - one spot in the PingBox".